### PR TITLE
feat: add GitHub issue templates for MA and RT issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 ReadTracker Documentation
+    url: https://github.com/Duongntd/myapps/blob/main/USER_GUIDE.md
+    about: Check the user guide for ReadTracker features and usage
+  - name: 🏗️ Project Plan
+    url: https://github.com/Duongntd/myapps/blob/main/PROJECT_PLAN.md
+    about: View the project plan and roadmap

--- a/.github/ISSUE_TEMPLATE/ma-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/ma-issue-template.yml
@@ -1,0 +1,97 @@
+name: MyApps Issue (MA)
+description: Create an issue for the MyApps platform (main app level)
+title: "MA: [Issue Title]"
+labels: ["bug", "enhancement", "documentation", "question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: This template is for issues related to the MyApps platform (main app level).
+        Please use the "RT: ReadTracker Issue" template for ReadTracker-specific issues.
+        
+        **Issue Format**: The title should start with "MA:" followed by a colon and the issue title.
+        Example: "MA: Add new app to home page"
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What type of issue is this?
+      options:
+        - Bug
+        - Enhancement
+        - Documentation
+        - Question
+        - Feature Request
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and detailed description of the issue
+      placeholder: Describe the issue, what you expected to happen, and what actually happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce (if applicable)
+      description: If this is a bug, please provide steps to reproduce the issue
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: A clear description of what you expected to happen.
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: A clear description of what actually happened.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (if applicable)
+      description: Add screenshots to help explain your issue
+      placeholder: Drag and drop images here or paste image URLs
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide information about your environment
+      placeholder: |
+        - OS: [e.g., macOS, Windows, Linux]
+        - Browser: [e.g., Chrome, Firefox, Safari]
+        - Version: [e.g., 1.0.0]
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, links, or information about the issue here
+      placeholder: Any additional information that might be helpful
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: I have provided all relevant information
+          required: true
+        - label: I have included screenshots if applicable
+          required: false

--- a/.github/ISSUE_TEMPLATE/rt-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/rt-issue-template.yml
@@ -1,0 +1,113 @@
+name: ReadTracker Issue (RT)
+description: Create an issue for the ReadTracker app
+title: "RT: [Issue Title]"
+labels: ["bug", "enhancement", "documentation", "question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: This template is for issues related to the ReadTracker app.
+        Please use the "MA: MyApps Issue" template for MyApps platform-level issues.
+        
+        **Issue Format**: The title should start with "RT:" followed by a colon and the issue title.
+        Example: "RT: Add book cover image upload"
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What type of issue is this?
+      options:
+        - Bug
+        - Enhancement
+        - Documentation
+        - Question
+        - Feature Request
+    validations:
+      required: true
+
+  - type: dropdown
+    id: readtracker-area
+    attributes:
+      label: ReadTracker Area
+      description: Which area of ReadTracker does this issue relate to?
+      options:
+        - Dashboard
+        - Reading Sessions
+        - Books Management
+        - Goals
+        - Settings
+        - Authentication
+        - General
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and detailed description of the issue
+      placeholder: Describe the issue, what you expected to happen, and what actually happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce (if applicable)
+      description: If this is a bug, please provide steps to reproduce the issue
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: A clear description of what you expected to happen.
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: A clear description of what actually happened.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (if applicable)
+      description: Add screenshots to help explain your issue
+      placeholder: Drag and drop images here or paste image URLs
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide information about your environment
+      placeholder: |
+        - OS: [e.g., macOS, Windows, Linux]
+        - Browser: [e.g., Chrome, Firefox, Safari]
+        - Version: [e.g., 1.0.0]
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, links, or information about the issue here
+      placeholder: Any additional information that might be helpful
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: I have provided all relevant information
+          required: true
+        - label: I have included screenshots if applicable
+          required: false


### PR DESCRIPTION
- Create MA (MyApps) issue template with MA: prefix format
- Create RT (ReadTracker) issue template with RT: prefix format
- Add config.yml to organize templates and disable blank issues
- Include comprehensive fields: issue type, description, steps to reproduce
- Add ReadTracker-specific area selector in RT template
- Configure labels: bug, enhancement, documentation, question
- Add validation and checklist sections to both templates

Closes #15