### PR TITLE
feat: add markdown support for release notes and fix version separation

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -113,14 +113,11 @@ jobs:
             MA_RELEASE_NOTES="$NOTES"
             # RT values remain empty (will use defaults from version.ts)
           elif [ "$PREFIX" = "rt" ]; then
-            # Update RT version info
+            # Update RT version info only
             RT_VERSION="$VERSION"
             RT_RELEASE_TIME="$RELEASE_TIME"
             RT_RELEASE_NOTES="$NOTES"
-            # Also update MA to maintain backward compatibility
-            MA_VERSION="$VERSION"
-            MA_RELEASE_TIME="$RELEASE_TIME"
-            MA_RELEASE_NOTES=""
+            # MA values remain unchanged (RT releases should NOT update MA version)
           fi
           
           # Escape release notes for output
@@ -134,18 +131,15 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           
           # Only output RT version info if prefix is "rt" (to prevent RT version from updating on MA releases)
+          # When prefix is not "rt", don't output RT values at all so they remain undefined
           if [ "$PREFIX" = "rt" ]; then
             echo "rt_version=$RT_VERSION" >> $GITHUB_OUTPUT
             echo "rt_release_time=$RT_RELEASE_TIME" >> $GITHUB_OUTPUT
             echo "rt_release_notes<<EOF" >> $GITHUB_OUTPUT
             echo "$RT_RELEASE_NOTES_ESCAPED" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
-          else
-            # Output empty values so they won't be set in the build step
-            echo "rt_version=" >> $GITHUB_OUTPUT
-            echo "rt_release_time=" >> $GITHUB_OUTPUT
-            echo "rt_release_notes=" >> $GITHUB_OUTPUT
           fi
+          # When prefix is not "rt", RT values are not output, so they'll be undefined in build step
 
       - name: Build with version and release notes
         env:
@@ -155,6 +149,9 @@ jobs:
           VITE_MA_VERSION: ${{ steps.version-env.outputs.ma_version }}
           VITE_MA_RELEASE_TIME: ${{ steps.version-env.outputs.ma_release_time }}
           VITE_MA_RELEASE_NOTES: ${{ steps.version-env.outputs.ma_release_notes }}
+          # Only set RT env vars if they exist (when prefix is "rt")
+          # When prefix is "ma", RT values are not output, so they'll be undefined here
+          # This prevents RT version/date from updating on MA releases
           VITE_RT_VERSION: ${{ steps.version-env.outputs.rt_version }}
           VITE_RT_RELEASE_TIME: ${{ steps.version-env.outputs.rt_release_time }}
           VITE_RT_RELEASE_NOTES: ${{ steps.version-env.outputs.rt_release_notes }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "chart.js": "^4.4.1",
         "date-fns": "^3.3.1",
         "firebase": "^10.11.1",
+        "marked": "^13.0.3",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
         "vue-chartjs": "^5.3.0",
@@ -7953,7 +7954,6 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
       "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chart.js": "^4.4.1",
     "date-fns": "^3.3.1",
     "firebase": "^10.11.1",
+    "marked": "^13.0.3",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
     "vue-chartjs": "^5.3.0",

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -4,6 +4,8 @@
  * Supports both MyApps (MA) and Read Tracker (RT) version prefixes
  */
 
+import { marked } from 'marked'
+
 // Version will be injected by Vite during build
 // For backward compatibility, use APP_VERSION if specific versions not set
 export const APP_VERSION = import.meta.env.VITE_APP_VERSION || '1.0.0'
@@ -118,35 +120,36 @@ export function getVersionWithReleaseDate(): string {
 
 /**
  * Get release notes formatted for display (default)
- * Converts markdown-style newlines to HTML line breaks
+ * Renders markdown to HTML
  */
 export function getFormattedReleaseNotes(): string {
   if (!RELEASE_NOTES) return ''
-  // Convert \n to actual newlines and escape HTML
-  return RELEASE_NOTES
-    .replace(/\\n/g, '\n')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  // Convert escaped newlines to actual newlines
+  const notes = RELEASE_NOTES.replace(/\\n/g, '\n')
+  // Render markdown to HTML
+  return marked.parse(notes) as string
 }
 
 /**
  * Get MyApps (MA) release notes formatted for display
+ * Renders markdown to HTML
  */
 export function getMAFormattedReleaseNotes(): string {
   if (!MA_RELEASE_NOTES) return ''
-  return MA_RELEASE_NOTES
-    .replace(/\\n/g, '\n')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  // Convert escaped newlines to actual newlines
+  const notes = MA_RELEASE_NOTES.replace(/\\n/g, '\n')
+  // Render markdown to HTML
+  return marked.parse(notes) as string
 }
 
 /**
  * Get Read Tracker (RT) release notes formatted for display
+ * Renders markdown to HTML
  */
 export function getRTFormattedReleaseNotes(): string {
   if (!RT_RELEASE_NOTES) return ''
-  return RT_RELEASE_NOTES
-    .replace(/\\n/g, '\n')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  // Convert escaped newlines to actual newlines
+  const notes = RT_RELEASE_NOTES.replace(/\\n/g, '\n')
+  // Render markdown to HTML
+  return marked.parse(notes) as string
 }

--- a/src/views/ReadTracker/Settings.vue
+++ b/src/views/ReadTracker/Settings.vue
@@ -17,7 +17,7 @@
         <!-- Release Notes -->
         <div v-if="hasReleaseNotes" class="mt-4 pt-4 border-t border-gray-200">
           <h4 class="text-sm font-semibold text-gray-900 mb-2">{{ $t('settings.releaseNotes') }}</h4>
-          <div class="text-xs text-gray-600 whitespace-pre-line">{{ formattedReleaseNotes }}</div>
+          <div class="text-xs text-gray-600 markdown-content" v-html="formattedReleaseNotes"></div>
         </div>
       </div>
     </div>
@@ -44,3 +44,83 @@ const showReleaseInfo = computed(() => import.meta.env.PROD)
 const formattedReleaseNotes = computed(() => getRTFormattedReleaseNotes())
 const hasReleaseNotes = computed(() => !!versionInfo.value.releaseNotes)
 </script>
+
+<style scoped>
+.markdown-content :deep(h1),
+.markdown-content :deep(h2),
+.markdown-content :deep(h3),
+.markdown-content :deep(h4) {
+  font-weight: 600;
+  margin-top: 0.75em;
+  margin-bottom: 0.5em;
+  color: #111827;
+}
+
+.markdown-content :deep(h1) { font-size: 1.25em; }
+.markdown-content :deep(h2) { font-size: 1.125em; }
+.markdown-content :deep(h3) { font-size: 1em; }
+.markdown-content :deep(h4) { font-size: 0.875em; }
+
+.markdown-content :deep(p) {
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.markdown-content :deep(ul),
+.markdown-content :deep(ol) {
+  margin-left: 1.25em;
+  margin-bottom: 0.5em;
+  padding-left: 0.5em;
+}
+
+.markdown-content :deep(li) {
+  margin-bottom: 0.25em;
+}
+
+.markdown-content :deep(strong) {
+  font-weight: 600;
+  color: #111827;
+}
+
+.markdown-content :deep(em) {
+  font-style: italic;
+}
+
+.markdown-content :deep(code) {
+  background-color: #f3f4f6;
+  padding: 0.125em 0.25em;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, monospace;
+  font-size: 0.875em;
+}
+
+.markdown-content :deep(pre) {
+  background-color: #f3f4f6;
+  padding: 0.75em;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  margin-bottom: 0.5em;
+}
+
+.markdown-content :deep(pre code) {
+  background-color: transparent;
+  padding: 0;
+}
+
+.markdown-content :deep(a) {
+  color: #4f46e5;
+  text-decoration: underline;
+}
+
+.markdown-content :deep(a:hover) {
+  color: #4338ca;
+}
+
+.markdown-content :deep(blockquote) {
+  border-left: 3px solid #d1d5db;
+  padding-left: 0.75em;
+  margin-left: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+</style>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -38,7 +38,7 @@
         <!-- Release Notes -->
         <div v-if="hasReleaseNotes" class="mt-4 pt-4 border-t border-gray-200">
           <h4 class="text-sm font-semibold text-gray-900 mb-2">{{ $t('settings.releaseNotes') }}</h4>
-          <div class="text-xs text-gray-600 whitespace-pre-line">{{ formattedReleaseNotes }}</div>
+          <div class="text-xs text-gray-600 markdown-content" v-html="formattedReleaseNotes"></div>
         </div>
       </div>
     </div>
@@ -61,3 +61,83 @@ const showReleaseInfo = computed(() => import.meta.env.PROD)
 const formattedReleaseNotes = computed(() => getMAFormattedReleaseNotes())
 const hasReleaseNotes = computed(() => !!versionInfo.value.releaseNotes)
 </script>
+
+<style scoped>
+.markdown-content :deep(h1),
+.markdown-content :deep(h2),
+.markdown-content :deep(h3),
+.markdown-content :deep(h4) {
+  font-weight: 600;
+  margin-top: 0.75em;
+  margin-bottom: 0.5em;
+  color: #111827;
+}
+
+.markdown-content :deep(h1) { font-size: 1.25em; }
+.markdown-content :deep(h2) { font-size: 1.125em; }
+.markdown-content :deep(h3) { font-size: 1em; }
+.markdown-content :deep(h4) { font-size: 0.875em; }
+
+.markdown-content :deep(p) {
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.markdown-content :deep(ul),
+.markdown-content :deep(ol) {
+  margin-left: 1.25em;
+  margin-bottom: 0.5em;
+  padding-left: 0.5em;
+}
+
+.markdown-content :deep(li) {
+  margin-bottom: 0.25em;
+}
+
+.markdown-content :deep(strong) {
+  font-weight: 600;
+  color: #111827;
+}
+
+.markdown-content :deep(em) {
+  font-style: italic;
+}
+
+.markdown-content :deep(code) {
+  background-color: #f3f4f6;
+  padding: 0.125em 0.25em;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, monospace;
+  font-size: 0.875em;
+}
+
+.markdown-content :deep(pre) {
+  background-color: #f3f4f6;
+  padding: 0.75em;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  margin-bottom: 0.5em;
+}
+
+.markdown-content :deep(pre code) {
+  background-color: transparent;
+  padding: 0;
+}
+
+.markdown-content :deep(a) {
+  color: #4f46e5;
+  text-decoration: underline;
+}
+
+.markdown-content :deep(a:hover) {
+  color: #4338ca;
+}
+
+.markdown-content :deep(blockquote) {
+  border-left: 3px solid #d1d5db;
+  padding-left: 0.75em;
+  margin-left: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,8 +18,14 @@ const maReleaseNotes = process.env.VITE_MA_RELEASE_NOTES || ''
 
 // RT-specific version info (defaults to package.json version to keep it separate from MA releases)
 // Only updates when VITE_RT_VERSION is explicitly set (i.e., on rt- releases)
+// When VITE_RT_VERSION is undefined (not set), use package.json version (doesn't change on MA releases)
 const rtVersion = process.env.VITE_RT_VERSION || packageJson.version || '1.0.0'
-const rtReleaseTime = process.env.VITE_RT_RELEASE_TIME || releaseTime
+// RT release time: only use if explicitly set
+// When undefined (not set), use a constant default to prevent RT date from updating on MA releases
+// This ensures RT release date only changes when an rt- release is made
+const rtReleaseTime = (process.env.VITE_RT_RELEASE_TIME && process.env.VITE_RT_RELEASE_TIME.trim() !== '')
+  ? process.env.VITE_RT_RELEASE_TIME
+  : new Date('2024-01-01T00:00:00Z').toISOString() // Constant default that doesn't change
 const rtReleaseNotes = process.env.VITE_RT_RELEASE_NOTES || ''
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
- Add markdown rendering for release notes using marked library
- Update Settings.vue and ReadTracker/Settings.vue to render markdown HTML
- Add CSS styles for markdown content (headings, lists, code, links, etc.)
- Fix workflow: RT releases should NOT update MA version
- Fix RT release date: prevent updates on MA releases by using constant default
- Only output RT version info when prefix is 'rt' (not on MA releases)
- Update vite.config.ts to handle undefined RT values properly

Fixes #20