### PR TITLE
feat: remove MA and RT versioning, simplify to single app version

### DIFF
--- a/.github/ISSUE_TEMPLATE/ma-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/ma-issue-template.yml
@@ -1,17 +1,7 @@
 name: MyApps Issue (MA)
 description: Create an issue for the MyApps platform (main app level)
 title: "MA: [Issue Title]"
-labels: ["bug", "enhancement", "documentation", "question"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **Note**: This template is for issues related to the MyApps platform (main app level).
-        Please use the "RT: ReadTracker Issue" template for ReadTracker-specific issues.
-        
-        **Issue Format**: The title should start with "MA:" followed by a colon and the issue title.
-        Example: "MA: Add new app to home page"
-
   - type: dropdown
     id: issue-type
     attributes:
@@ -34,64 +24,3 @@ body:
       placeholder: Describe the issue, what you expected to happen, and what actually happened...
     validations:
       required: true
-
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: Steps to Reproduce (if applicable)
-      description: If this is a bug, please provide steps to reproduce the issue
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: A clear description of what you expected to happen.
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: Actual Behavior
-      description: What actually happened?
-      placeholder: A clear description of what actually happened.
-
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots (if applicable)
-      description: Add screenshots to help explain your issue
-      placeholder: Drag and drop images here or paste image URLs
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: Please provide information about your environment
-      placeholder: |
-        - OS: [e.g., macOS, Windows, Linux]
-        - Browser: [e.g., Chrome, Firefox, Safari]
-        - Version: [e.g., 1.0.0]
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Add any other context, links, or information about the issue here
-      placeholder: Any additional information that might be helpful
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Checklist
-      options:
-        - label: I have searched existing issues to ensure this is not a duplicate
-          required: true
-        - label: I have provided all relevant information
-          required: true
-        - label: I have included screenshots if applicable
-          required: false

--- a/.github/ISSUE_TEMPLATE/rt-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/rt-issue-template.yml
@@ -1,17 +1,7 @@
 name: ReadTracker Issue (RT)
 description: Create an issue for the ReadTracker app
 title: "RT: [Issue Title]"
-labels: ["bug", "enhancement", "documentation", "question"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **Note**: This template is for issues related to the ReadTracker app.
-        Please use the "MA: MyApps Issue" template for MyApps platform-level issues.
-        
-        **Issue Format**: The title should start with "RT:" followed by a colon and the issue title.
-        Example: "RT: Add book cover image upload"
-
   - type: dropdown
     id: issue-type
     attributes:
@@ -26,22 +16,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: readtracker-area
-    attributes:
-      label: ReadTracker Area
-      description: Which area of ReadTracker does this issue relate to?
-      options:
-        - Dashboard
-        - Reading Sessions
-        - Books Management
-        - Goals
-        - Settings
-        - Authentication
-        - General
-    validations:
-      required: true
-
   - type: textarea
     id: description
     attributes:
@@ -50,64 +24,3 @@ body:
       placeholder: Describe the issue, what you expected to happen, and what actually happened...
     validations:
       required: true
-
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: Steps to Reproduce (if applicable)
-      description: If this is a bug, please provide steps to reproduce the issue
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: A clear description of what you expected to happen.
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: Actual Behavior
-      description: What actually happened?
-      placeholder: A clear description of what actually happened.
-
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots (if applicable)
-      description: Add screenshots to help explain your issue
-      placeholder: Drag and drop images here or paste image URLs
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: Please provide information about your environment
-      placeholder: |
-        - OS: [e.g., macOS, Windows, Linux]
-        - Browser: [e.g., Chrome, Firefox, Safari]
-        - Version: [e.g., 1.0.0]
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Add any other context, links, or information about the issue here
-      placeholder: Any additional information that might be helpful
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Checklist
-      options:
-        - label: I have searched existing issues to ensure this is not a duplicate
-          required: true
-        - label: I have provided all relevant information
-          required: true
-        - label: I have included screenshots if applicable
-          required: false

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -28,25 +28,7 @@ jobs:
           # Remove 'v' prefix if present
           VERSION="${VERSION#v}"
           
-          # Detect version prefix (ma- or rt-)
-          PREFIX=""
-          CLEAN_VERSION="$VERSION"
-          
-          if [[ "$VERSION" =~ ^ma- ]]; then
-            PREFIX="ma"
-            CLEAN_VERSION="${VERSION#ma-}"
-            # Remove 'v' prefix if present after removing ma- prefix
-            CLEAN_VERSION="${CLEAN_VERSION#v}"
-          elif [[ "$VERSION" =~ ^rt- ]]; then
-            PREFIX="rt"
-            CLEAN_VERSION="${VERSION#rt-}"
-            # Remove 'v' prefix if present after removing rt- prefix
-            CLEAN_VERSION="${CLEAN_VERSION#v}"
-          fi
-          
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-          echo "original_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "prefix=$PREFIX" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           
           # Get release notes and escape for JSON
@@ -86,75 +68,12 @@ jobs:
           # Clean up
           rm -f /tmp/firebase-config.json
 
-      - name: Prepare version environment variables
-        id: version-env
-        run: |
-          PREFIX="${{ steps.release.outputs.prefix }}"
-          VERSION="${{ steps.release.outputs.version }}"
-          RELEASE_TIME="${{ github.event.release.published_at }}"
-          NOTES="${{ steps.release.outputs.notes }}"
-          
-          # Initialize MA values (default for backward compatibility)
-          MA_VERSION="$VERSION"
-          MA_RELEASE_TIME="$RELEASE_TIME"
-          MA_RELEASE_NOTES=""
-          
-          # Initialize RT values - only update when prefix is "rt"
-          # When prefix is "ma", RT values should not be updated (keep previous/separate)
-          RT_VERSION=""
-          RT_RELEASE_TIME=""
-          RT_RELEASE_NOTES=""
-          
-          # Update based on prefix
-          if [ "$PREFIX" = "ma" ]; then
-            # Update MA version info
-            MA_VERSION="$VERSION"
-            MA_RELEASE_TIME="$RELEASE_TIME"
-            MA_RELEASE_NOTES="$NOTES"
-            # RT values remain empty (will use defaults from version.ts)
-          elif [ "$PREFIX" = "rt" ]; then
-            # Update RT version info only
-            RT_VERSION="$VERSION"
-            RT_RELEASE_TIME="$RELEASE_TIME"
-            RT_RELEASE_NOTES="$NOTES"
-            # MA values remain unchanged (RT releases should NOT update MA version)
-          fi
-          
-          # Escape release notes for output
-          MA_RELEASE_NOTES_ESCAPED=$(echo "$MA_RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-          RT_RELEASE_NOTES_ESCAPED=$(echo "$RT_RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-          
-          echo "ma_version=$MA_VERSION" >> $GITHUB_OUTPUT
-          echo "ma_release_time=$MA_RELEASE_TIME" >> $GITHUB_OUTPUT
-          echo "ma_release_notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$MA_RELEASE_NOTES_ESCAPED" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          
-          # Only output RT version info if prefix is "rt" (to prevent RT version from updating on MA releases)
-          # When prefix is not "rt", don't output RT values at all so they remain undefined
-          if [ "$PREFIX" = "rt" ]; then
-            echo "rt_version=$RT_VERSION" >> $GITHUB_OUTPUT
-            echo "rt_release_time=$RT_RELEASE_TIME" >> $GITHUB_OUTPUT
-            echo "rt_release_notes<<EOF" >> $GITHUB_OUTPUT
-            echo "$RT_RELEASE_NOTES_ESCAPED" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
-          # When prefix is not "rt", RT values are not output, so they'll be undefined in build step
 
       - name: Build with version and release notes
         env:
           VITE_APP_VERSION: ${{ steps.release.outputs.version }}
           VITE_RELEASE_TIME: ${{ github.event.release.published_at }}
           VITE_RELEASE_NOTES: ${{ steps.release.outputs.notes }}
-          VITE_MA_VERSION: ${{ steps.version-env.outputs.ma_version }}
-          VITE_MA_RELEASE_TIME: ${{ steps.version-env.outputs.ma_release_time }}
-          VITE_MA_RELEASE_NOTES: ${{ steps.version-env.outputs.ma_release_notes }}
-          # Only set RT env vars if they exist (when prefix is "rt")
-          # When prefix is "ma", RT values are not output, so they'll be undefined here
-          # This prevents RT version/date from updating on MA releases
-          VITE_RT_VERSION: ${{ steps.version-env.outputs.rt_version }}
-          VITE_RT_RELEASE_TIME: ${{ steps.version-env.outputs.rt_release_time }}
-          VITE_RT_RELEASE_NOTES: ${{ steps.version-env.outputs.rt_release_notes }}
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.api_key }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.auth_domain }}
           VITE_FIREBASE_PROJECT_ID: ${{ steps.firebase-config.outputs.project_id }}

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,26 +1,14 @@
 /**
  * Version tracking utility
  * Provides app version information from package.json and release metadata
- * Supports both MyApps (MA) and Read Tracker (RT) version prefixes
  */
 
 import { marked } from 'marked'
 
 // Version will be injected by Vite during build
-// For backward compatibility, use APP_VERSION if specific versions not set
 export const APP_VERSION = import.meta.env.VITE_APP_VERSION || '1.0.0'
 export const RELEASE_TIME = import.meta.env.VITE_RELEASE_TIME || new Date().toISOString()
 export const RELEASE_NOTES = import.meta.env.VITE_RELEASE_NOTES || ''
-
-// MyApps (MA) specific version info
-export const MA_VERSION = import.meta.env.VITE_MA_VERSION || APP_VERSION
-export const MA_RELEASE_TIME = import.meta.env.VITE_MA_RELEASE_TIME || RELEASE_TIME
-export const MA_RELEASE_NOTES = import.meta.env.VITE_MA_RELEASE_NOTES || ''
-
-// Read Tracker (RT) specific version info
-export const RT_VERSION = import.meta.env.VITE_RT_VERSION || APP_VERSION
-export const RT_RELEASE_TIME = import.meta.env.VITE_RT_RELEASE_TIME || RELEASE_TIME
-export const RT_RELEASE_NOTES = import.meta.env.VITE_RT_RELEASE_NOTES || ''
 
 export interface VersionInfo {
   version: string
@@ -30,7 +18,7 @@ export interface VersionInfo {
 }
 
 /**
- * Get complete version information (default - uses APP_VERSION for backward compatibility)
+ * Get complete version information
  */
 export function getVersionInfo(): VersionInfo {
   const releaseDate = new Date(RELEASE_TIME).toLocaleDateString('en-US', {
@@ -50,64 +38,10 @@ export function getVersionInfo(): VersionInfo {
 }
 
 /**
- * Get MyApps (MA) version information
- */
-export function getMAVersionInfo(): VersionInfo {
-  const releaseDate = new Date(MA_RELEASE_TIME).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  })
-
-  return {
-    version: MA_VERSION,
-    releaseTime: MA_RELEASE_TIME,
-    releaseDate,
-    releaseNotes: MA_RELEASE_NOTES
-  }
-}
-
-/**
- * Get Read Tracker (RT) version information
- */
-export function getRTVersionInfo(): VersionInfo {
-  const releaseDate = new Date(RT_RELEASE_TIME).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  })
-
-  return {
-    version: RT_VERSION,
-    releaseTime: RT_RELEASE_TIME,
-    releaseDate,
-    releaseNotes: RT_RELEASE_NOTES
-  }
-}
-
-/**
- * Get formatted version string for display (default)
+ * Get formatted version string for display
  */
 export function getVersionString(): string {
   return `v${APP_VERSION}`
-}
-
-/**
- * Get formatted MyApps (MA) version string for display
- */
-export function getMAVersionString(): string {
-  return `v${MA_VERSION}`
-}
-
-/**
- * Get formatted Read Tracker (RT) version string for display
- */
-export function getRTVersionString(): string {
-  return `v${RT_VERSION}`
 }
 
 /**
@@ -119,37 +53,13 @@ export function getVersionWithReleaseDate(): string {
 }
 
 /**
- * Get release notes formatted for display (default)
+ * Get release notes formatted for display
  * Renders markdown to HTML
  */
 export function getFormattedReleaseNotes(): string {
   if (!RELEASE_NOTES) return ''
   // Convert escaped newlines to actual newlines
   const notes = RELEASE_NOTES.replace(/\\n/g, '\n')
-  // Render markdown to HTML
-  return marked.parse(notes) as string
-}
-
-/**
- * Get MyApps (MA) release notes formatted for display
- * Renders markdown to HTML
- */
-export function getMAFormattedReleaseNotes(): string {
-  if (!MA_RELEASE_NOTES) return ''
-  // Convert escaped newlines to actual newlines
-  const notes = MA_RELEASE_NOTES.replace(/\\n/g, '\n')
-  // Render markdown to HTML
-  return marked.parse(notes) as string
-}
-
-/**
- * Get Read Tracker (RT) release notes formatted for display
- * Renders markdown to HTML
- */
-export function getRTFormattedReleaseNotes(): string {
-  if (!RT_RELEASE_NOTES) return ''
-  // Convert escaped newlines to actual newlines
-  const notes = RT_RELEASE_NOTES.replace(/\\n/g, '\n')
   // Render markdown to HTML
   return marked.parse(notes) as string
 }

--- a/src/views/ReadTracker/Settings.vue
+++ b/src/views/ReadTracker/Settings.vue
@@ -6,22 +6,6 @@
       <p class="text-sm text-gray-600 mt-1">{{ $t('readTrackerSettings.subtitle') }}</p>
     </div>
 
-    <!-- Read Tracker App Information -->
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-lg font-semibold text-gray-900 mb-4">{{ $t('readTrackerSettings.about') }}</h3>
-      <div class="space-y-3 text-sm text-gray-600">
-        <p><strong>{{ $t('readTracker.title') }}</strong> - {{ $t('readTracker.subtitle') }}</p>
-        <p>{{ $t('settings.version') }}: <span class="font-mono font-medium">{{ versionString }}</span></p>
-        <p v-if="showReleaseInfo" class="text-xs text-gray-500">{{ $t('settings.releaseDate') }}: {{ releaseDate }}</p>
-        
-        <!-- Release Notes -->
-        <div v-if="hasReleaseNotes" class="mt-4 pt-4 border-t border-gray-200">
-          <h4 class="text-sm font-semibold text-gray-900 mb-2">{{ $t('settings.releaseNotes') }}</h4>
-          <div class="text-xs text-gray-600 markdown-content" v-html="formattedReleaseNotes"></div>
-        </div>
-      </div>
-    </div>
-
     <!-- Read Tracker Specific Settings -->
     <div class="bg-white rounded-lg shadow p-6">
       <h3 class="text-lg font-semibold text-gray-900 mb-4">{{ $t('readTrackerSettings.readTrackerSettings') }}</h3>
@@ -31,18 +15,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { getRTVersionString, getRTVersionInfo, getRTFormattedReleaseNotes } from '@/utils/version'
 
 useI18n() // Required for $t() in template
-
-const versionString = computed(() => getRTVersionString())
-const versionInfo = computed(() => getRTVersionInfo())
-const releaseDate = computed(() => versionInfo.value.releaseDate)
-const showReleaseInfo = computed(() => import.meta.env.PROD)
-const formattedReleaseNotes = computed(() => getRTFormattedReleaseNotes())
-const hasReleaseNotes = computed(() => !!versionInfo.value.releaseNotes)
 </script>
 
 <style scoped>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -49,16 +49,16 @@
 import { computed } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
-import { getMAVersionString, getMAVersionInfo, getMAFormattedReleaseNotes } from '@/utils/version'
+import { getVersionString, getVersionInfo, getFormattedReleaseNotes } from '@/utils/version'
 
 useI18n() // Required for $t() in template
 const authStore = useAuthStore()
 
-const versionString = computed(() => getMAVersionString())
-const versionInfo = computed(() => getMAVersionInfo())
+const versionString = computed(() => getVersionString())
+const versionInfo = computed(() => getVersionInfo())
 const releaseDate = computed(() => versionInfo.value.releaseDate)
 const showReleaseInfo = computed(() => import.meta.env.PROD)
-const formattedReleaseNotes = computed(() => getMAFormattedReleaseNotes())
+const formattedReleaseNotes = computed(() => getFormattedReleaseNotes())
 const hasReleaseNotes = computed(() => !!versionInfo.value.releaseNotes)
 </script>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,36 +11,13 @@ const releaseTime = process.env.VITE_RELEASE_TIME || new Date().toISOString()
 // Release notes from GitHub release (if available)
 const releaseNotes = process.env.VITE_RELEASE_NOTES || ''
 
-// MA-specific version info (defaults to app version)
-const maVersion = process.env.VITE_MA_VERSION || appVersion
-const maReleaseTime = process.env.VITE_MA_RELEASE_TIME || releaseTime
-const maReleaseNotes = process.env.VITE_MA_RELEASE_NOTES || ''
-
-// RT-specific version info (defaults to package.json version to keep it separate from MA releases)
-// Only updates when VITE_RT_VERSION is explicitly set (i.e., on rt- releases)
-// When VITE_RT_VERSION is undefined (not set), use package.json version (doesn't change on MA releases)
-const rtVersion = process.env.VITE_RT_VERSION || packageJson.version || '1.0.0'
-// RT release time: only use if explicitly set
-// When undefined (not set), use a constant default to prevent RT date from updating on MA releases
-// This ensures RT release date only changes when an rt- release is made
-const rtReleaseTime = (process.env.VITE_RT_RELEASE_TIME && process.env.VITE_RT_RELEASE_TIME.trim() !== '')
-  ? process.env.VITE_RT_RELEASE_TIME
-  : new Date('2024-01-01T00:00:00Z').toISOString() // Constant default that doesn't change
-const rtReleaseNotes = process.env.VITE_RT_RELEASE_NOTES || ''
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
     'import.meta.env.VITE_RELEASE_TIME': JSON.stringify(releaseTime),
-    'import.meta.env.VITE_RELEASE_NOTES': JSON.stringify(releaseNotes),
-    'import.meta.env.VITE_MA_VERSION': JSON.stringify(maVersion),
-    'import.meta.env.VITE_MA_RELEASE_TIME': JSON.stringify(maReleaseTime),
-    'import.meta.env.VITE_MA_RELEASE_NOTES': JSON.stringify(maReleaseNotes),
-    'import.meta.env.VITE_RT_VERSION': JSON.stringify(rtVersion),
-    'import.meta.env.VITE_RT_RELEASE_TIME': JSON.stringify(rtReleaseTime),
-    'import.meta.env.VITE_RT_RELEASE_NOTES': JSON.stringify(rtReleaseNotes)
+    'import.meta.env.VITE_RELEASE_NOTES': JSON.stringify(releaseNotes)
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Remove MA_VERSION, RT_VERSION and related functions from version.ts
- Update Settings.vue to use main app version functions
- Remove version display from ReadTracker/Settings.vue
- Remove MA/RT version environment variables from vite.config.ts
- Update deploy-release.yml to remove MA/RT prefix detection
- Simplify issue templates to only include Issue Type and Description

Closes #22