### PR TITLE
feat(portfolio): display CASH in My Holdings when totalCash > 0

### DIFF
--- a/e2e/portfolio-tracker.spec.ts
+++ b/e2e/portfolio-tracker.spec.ts
@@ -46,4 +46,24 @@ test.describe('Portfolio Tracker functionality', () => {
     await expect(transactionsTable.getByText('Trading 212')).toBeVisible()
     await expect(transactionsTable.getByText('AAPL')).toBeVisible()
   })
+
+  test('Dashboard: CASH is displayed like a stock in My Holdings when cash > 0 (#43)', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: /open app/i }).nth(1).click()
+    await expect(page).toHaveURL(/\/portfolio-tracker/)
+
+    await page.goto('/portfolio-tracker/settings')
+    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible()
+
+    const numberInputs = page.getByRole('spinbutton')
+    await numberInputs.first().fill('1000')
+    await numberInputs.nth(1).fill('5000')
+    await page.getByRole('button', { name: /save/i }).click()
+
+    await page.goto('/portfolio-tracker/dashboard')
+    await expect(page.getByRole('heading', { name: 'My Holdings' })).toBeVisible()
+    const holdingsTable = page.getByRole('table')
+    await expect(holdingsTable.getByText('CASH')).toBeVisible({ timeout: 8000 })
+    await expect(holdingsTable.getByText('$5,000.00')).toBeVisible()
+  })
 })

--- a/src/views/PortfolioTracker/Dashboard.spec.ts
+++ b/src/views/PortfolioTracker/Dashboard.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from '@/test/utils'
+import Dashboard from './Dashboard.vue'
+
+const mockFetchHoldings = vi.fn()
+const mockFetchTransactions = vi.fn()
+const mockFetchAccount = vi.fn()
+
+vi.mock('@/stores/portfolio', () => ({
+  usePortfolioStore: () => ({
+    holdings: [],
+    holdingsWithPrices: [],
+    totalCash: 5000,
+    totalPortfolioValue: 5000,
+    totalInvested: 0,
+    loading: false,
+    fetchHoldings: mockFetchHoldings,
+    fetchTransactions: mockFetchTransactions,
+    fetchAccount: mockFetchAccount,
+    updateStockPrice: vi.fn()
+  })
+}))
+
+vi.mock('@/utils/stockPrice', () => ({
+  getMultipleStockPrices: vi.fn().mockResolvedValue([])
+}))
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows My Holdings section', async () => {
+    const { findByRole } = renderWithProviders(Dashboard)
+    const heading = await findByRole('heading', { name: 'My Holdings' })
+    expect(heading).toBeDefined()
+  })
+
+  it('displays CASH as a row in My Holdings when totalCash > 0 (#43)', async () => {
+    const { findByText } = renderWithProviders(Dashboard)
+    const cashCell = await findByText('CASH')
+    expect(cashCell).toBeDefined()
+  })
+})


### PR DESCRIPTION
- Added a new test to verify that CASH is displayed as a stock in the My Holdings section when totalCash is greater than zero.
- Updated the Dashboard.vue component to include a CASH row in the holdings table when totalCash is available.
- Introduced a computed property to manage the inclusion of the CASH row based on the totalCash value.

This enhancement improves the visibility of cash holdings in the portfolio tracker, addressing issue #43.