### PR TITLE
feat: add Task List app

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Users can only access their own data
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/src/components/TaskList/DayColumn.vue
+++ b/src/components/TaskList/DayColumn.vue
@@ -102,7 +102,7 @@ const dayNum = computed(() => dateObj.value.getDate())
 const activeCount = computed(() => props.dayTasks.length)
 
 const columnStyle = computed(() => {
-  if (props.isMobile) return { minWidth: '260px', flexShrink: 0, scrollSnapAlign: 'start' }
+  if (props.isMobile) return { minWidth: '220px', flexShrink: 0, scrollSnapAlign: 'start' }
   return { minHeight: '200px' }
 })
 

--- a/src/components/TaskList/DayColumn.vue
+++ b/src/components/TaskList/DayColumn.vue
@@ -1,0 +1,151 @@
+<template>
+  <div
+    class="day-column flex flex-col rounded-xl border bg-white dark:bg-gray-900 transition-colors"
+    :class="[
+      isToday ? 'border-primary-500 shadow-[0_0_0_1.5px] shadow-primary-500/30 bg-primary-50/20 dark:bg-primary-950/20' : 'border-gray-200 dark:border-gray-700',
+      dragOver ? 'border-primary-500 bg-primary-50 dark:bg-primary-950/30' : ''
+    ]"
+    :style="columnStyle"
+    :data-date="date"
+    @dragover.prevent="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <!-- Header -->
+    <div class="flex items-center justify-between px-3 py-2.5 border-b border-gray-200 dark:border-gray-700">
+      <span class="text-[0.7rem] font-semibold uppercase tracking-wider" :class="isToday ? 'text-primary-600 dark:text-primary-400' : 'text-gray-400'">
+        {{ dayName }}
+        <span
+          v-if="activeCount > 0"
+          class="ml-1.5 inline-block rounded-full px-1.5 py-px text-[0.65rem] font-semibold"
+          :class="isToday ? 'bg-primary-100 text-primary-600 dark:bg-primary-900/40 dark:text-primary-400' : 'bg-gray-100 text-gray-400 dark:bg-gray-800'"
+        >{{ activeCount }}</span>
+      </span>
+      <span
+        class="text-xs font-bold"
+        :class="isToday
+          ? 'bg-primary-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-[0.72rem]'
+          : 'text-gray-500 dark:text-gray-400'"
+      >{{ dayNum }}</span>
+    </div>
+
+    <!-- Tasks -->
+    <div ref="tasksContainer" class="flex-1 flex flex-col gap-1.5 p-1.5 min-h-[60px]">
+      <TransitionGroup name="card">
+        <TaskCard
+          v-for="task in dayTasks"
+          :key="task.id"
+          :task="task"
+          @drag-start="(id, e) => $emit('dragStart', id, e)"
+          @drag-end="$emit('dragEnd')"
+          @delete="id => $emit('delete', id)"
+          @status-change="(id, st) => $emit('statusChange', id, st)"
+          @priority-change="(id, p) => $emit('priorityChange', id, p)"
+          @update="t => $emit('update', t)"
+          @touch-drag="(id, x, y, phase) => $emit('touchDrag', id, x, y, phase)"
+        />
+      </TransitionGroup>
+      <div v-if="dayTasks.length === 0" class="text-center text-gray-400 dark:text-gray-600 text-xs py-6 italic opacity-60">
+        Nothing scheduled
+      </div>
+    </div>
+
+    <!-- Add button -->
+    <div
+      class="text-center text-xs text-gray-400 py-1.5 cursor-pointer border-t border-gray-200 dark:border-gray-700 rounded-b-xl transition-colors hover:bg-primary-50 hover:text-primary-600 dark:hover:bg-primary-950/30 dark:hover:text-primary-400"
+      @click="$emit('addTask', date)"
+    >+ Add</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { Task, TaskStatus, TaskPriority } from '@/views/TaskList/types'
+import { DAY_NAMES } from '@/views/TaskList/types'
+import TaskCard from './TaskCard.vue'
+
+const props = defineProps<{
+  date: string
+  dayTasks: Task[]
+  isToday: boolean
+  isMobile?: boolean
+}>()
+
+const emit = defineEmits<{
+  addTask: [date: string]
+  drop: [taskId: string, date: string, insertBeforeId?: string]
+  dragStart: [taskId: string, event: DragEvent]
+  dragEnd: []
+  delete: [taskId: string]
+  statusChange: [taskId: string, status: TaskStatus]
+  priorityChange: [taskId: string, priority: TaskPriority]
+  update: [task: Task]
+  touchDrag: [taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end']
+}>()
+
+const tasksContainer = ref<HTMLElement>()
+const dragOver = ref(false)
+
+const dateObj = computed(() => {
+  const [y, m, d] = props.date.split('-').map(Number)
+  return new Date(y, m - 1, d)
+})
+
+const dayName = computed(() => {
+  const jsDay = dateObj.value.getDay()
+  // Convert JS day (0=Sun) to our DAY_NAMES (0=Mon)
+  const idx = jsDay === 0 ? 6 : jsDay - 1
+  return DAY_NAMES[idx]
+})
+
+const dayNum = computed(() => dateObj.value.getDate())
+const activeCount = computed(() => props.dayTasks.length)
+
+const columnStyle = computed(() => {
+  if (props.isMobile) return { minWidth: '260px', flexShrink: 0, scrollSnapAlign: 'start' }
+  return { minHeight: '200px' }
+})
+
+function getDropTarget(y: number): string | undefined {
+  if (!tasksContainer.value) return undefined
+  const cards = Array.from(tasksContainer.value.querySelectorAll('.task-card'))
+  for (const card of cards) {
+    const rect = card.getBoundingClientRect()
+    if (y < rect.top + rect.height / 2) {
+      return (card as HTMLElement).dataset.id
+    }
+  }
+  return undefined
+}
+
+function onDragOver(_e: DragEvent) {
+  dragOver.value = true
+}
+
+function onDragLeave() {
+  dragOver.value = false
+}
+
+function onDrop(e: DragEvent) {
+  dragOver.value = false
+  const taskId = e.dataTransfer?.getData('text/plain')
+  if (!taskId) return
+  const insertBeforeId = getDropTarget(e.clientY)
+  emit('drop', taskId, props.date, insertBeforeId)
+}
+</script>
+
+<style scoped>
+.card-enter-active,
+.card-leave-active {
+  transition: all 0.2s ease;
+}
+.card-enter-from {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+.card-leave-to {
+  opacity: 0;
+  transform: translateX(16px);
+}
+</style>

--- a/src/components/TaskList/DayColumn.vue
+++ b/src/components/TaskList/DayColumn.vue
@@ -42,7 +42,7 @@
           @status-change="(id, st) => $emit('statusChange', id, st)"
           @priority-change="(id, p) => $emit('priorityChange', id, p)"
           @update="t => $emit('update', t)"
-          @touch-drag="(id, x, y, phase) => $emit('touchDrag', id, x, y, phase)"
+          @touch-drop="(id, date) => $emit('touchDrop', id, date)"
         />
       </TransitionGroup>
       <div v-if="dayTasks.length === 0" class="text-center text-gray-400 dark:text-gray-600 text-xs py-6 italic opacity-60">
@@ -80,7 +80,7 @@ const emit = defineEmits<{
   statusChange: [taskId: string, status: TaskStatus]
   priorityChange: [taskId: string, priority: TaskPriority]
   update: [task: Task]
-  touchDrag: [taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end']
+  touchDrop: [taskId: string, date: string]
 }>()
 
 const tasksContainer = ref<HTMLElement>()

--- a/src/components/TaskList/TaskCard.vue
+++ b/src/components/TaskList/TaskCard.vue
@@ -26,7 +26,8 @@
       <span
         v-if="task.tag"
         class="inline-block rounded px-1.5 py-0.5 text-xs font-semibold font-mono bg-primary-50 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
-      >{{ task.title }}</span>
+        v-text="task.title"
+      ></span>
       <span
         v-else
         ref="titleEl"
@@ -34,10 +35,11 @@
         :class="{ 'line-through': task.status === 'done' }"
         :contenteditable="true"
         spellcheck="false"
+        v-text="task.title"
         @blur="onTitleBlur"
         @keydown.enter.prevent="($event.target as HTMLElement).blur()"
         @keydown.escape="onTitleEscape"
-      >{{ task.title }}</span>
+      ></span>
 
       <!-- Delete -->
       <button
@@ -55,8 +57,9 @@
       spellcheck="false"
       @blur="onDescBlur"
       @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+      v-text="task.description"
       @keydown.escape="onDescEscape"
-    >{{ task.description }}</div>
+    ></div>
 
     <!-- Footer: status + priority -->
     <div class="flex items-center justify-between mt-1.5 gap-2">

--- a/src/components/TaskList/TaskCard.vue
+++ b/src/components/TaskList/TaskCard.vue
@@ -1,0 +1,294 @@
+<template>
+  <div
+    ref="cardEl"
+    class="task-card group relative rounded-lg p-3 text-sm transition-all"
+    :class="[
+      task.status === 'done' ? 'opacity-50' : '',
+      isDragging ? 'opacity-30' : '',
+      bgClass
+    ]"
+    :data-id="task.id"
+  >
+    <div class="flex items-start justify-between gap-1.5">
+      <!-- Drag handle -->
+      <span
+        class="drag-handle flex-shrink-0 cursor-grab text-xs leading-none select-none text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity pt-0.5 touch-manipulation"
+        :class="{ 'opacity-50': isMobile }"
+        draggable="true"
+        @dragstart="onDragStart"
+        @dragend="onDragEnd"
+        @touchstart.prevent="onTouchStart"
+        @touchmove.prevent="onTouchMove"
+        @touchend="onTouchEnd"
+      >&#x2807;</span>
+
+      <!-- Title -->
+      <span
+        v-if="task.tag"
+        class="inline-block rounded px-1.5 py-0.5 text-xs font-semibold font-mono bg-primary-50 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+      >{{ task.title }}</span>
+      <span
+        v-else
+        ref="titleEl"
+        class="editable flex-1 rounded px-1 py-0.5 -mx-1 -my-0.5 text-[0.78rem] font-semibold leading-snug cursor-text hover:bg-black/[0.04] focus:outline-2 focus:outline-primary-500 focus:bg-white dark:focus:bg-gray-800 transition-colors"
+        :class="{ 'line-through': task.status === 'done' }"
+        :contenteditable="true"
+        spellcheck="false"
+        @blur="onTitleBlur"
+        @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+        @keydown.escape="onTitleEscape"
+      >{{ task.title }}</span>
+
+      <!-- Delete -->
+      <button
+        class="flex-shrink-0 rounded p-0.5 text-sm leading-none text-transparent group-hover:text-gray-400 hover:!text-red-500 hover:!bg-red-50 dark:hover:!bg-red-900/20 transition-colors"
+        title="Delete"
+        @click="onDelete"
+      >&times;</button>
+    </div>
+
+    <!-- Description -->
+    <div
+      ref="descEl"
+      class="editable mt-1 rounded px-1 py-0.5 -mx-1 text-xs text-gray-500 dark:text-gray-400 leading-relaxed cursor-text hover:bg-black/[0.04] focus:outline-2 focus:outline-primary-500 focus:bg-white dark:focus:bg-gray-800 transition-colors"
+      :contenteditable="true"
+      spellcheck="false"
+      @blur="onDescBlur"
+      @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+      @keydown.escape="onDescEscape"
+    >{{ task.description }}</div>
+
+    <!-- Footer: status + priority -->
+    <div class="flex items-center justify-between mt-1.5 gap-2">
+      <!-- Status badge -->
+      <div class="relative" ref="statusWrapper">
+        <button
+          class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.65rem] font-semibold cursor-pointer select-none border-none transition-all hover:brightness-[0.93] hover:scale-[1.04] active:scale-[0.96]"
+          :class="statusBadgeClass"
+          @click.stop="toggleStatusDropdown"
+        >
+          <span class="w-[5px] h-[5px] rounded-full flex-shrink-0" :class="statusDotClass"></span>
+          <span>{{ STATUS_LABELS[task.status] }}</span>
+        </button>
+        <Transition name="dropdown">
+          <div
+            v-if="showStatusDropdown"
+            class="absolute top-full mt-1 z-50 min-w-[120px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1"
+            :class="dropdownAlign"
+          >
+            <div
+              v-for="st in STATUS_ORDER"
+              :key="st"
+              class="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-semibold cursor-pointer transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 whitespace-nowrap"
+              :class="statusOptionClass(st)"
+              @click.stop="onStatusChange(st)"
+            >
+              <span class="w-[5px] h-[5px] rounded-full flex-shrink-0" :class="statusOptionDotClass(st)"></span>
+              {{ STATUS_LABELS[st] }}
+            </div>
+          </div>
+        </Transition>
+      </div>
+
+      <!-- Priority dot -->
+      <button
+        class="flex items-center gap-1 text-[0.6rem] font-semibold uppercase tracking-wider cursor-pointer select-none transition-colors"
+        :class="priorityTextClass"
+        @click.stop="cyclePriority"
+        :title="'Priority: ' + task.priority"
+      >
+        <span class="w-[6px] h-[6px] rounded-full" :class="priorityDotClass"></span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import type { Task, TaskStatus, TaskPriority } from '@/views/TaskList/types'
+import { STATUS_ORDER, STATUS_LABELS } from '@/views/TaskList/types'
+
+const props = defineProps<{ task: Task }>()
+const emit = defineEmits<{
+  dragStart: [taskId: string, event: DragEvent]
+  dragEnd: []
+  delete: [taskId: string]
+  statusChange: [taskId: string, status: TaskStatus]
+  priorityChange: [taskId: string, priority: TaskPriority]
+  update: [task: Task]
+  touchDrag: [taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end']
+}>()
+
+const cardEl = ref<HTMLElement>()
+const titleEl = ref<HTMLElement>()
+const descEl = ref<HTMLElement>()
+const statusWrapper = ref<HTMLElement>()
+const showStatusDropdown = ref(false)
+const isDragging = ref(false)
+const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
+
+const bgClass = computed(() => {
+  return 'bg-gray-100 dark:bg-gray-800/60 hover:shadow-sm'
+})
+
+const statusBadgeClass = computed(() => {
+  const map: Record<TaskStatus, string> = {
+    todo: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+    inprogress: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+    onhold: 'bg-orange-50 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400',
+    done: 'bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400'
+  }
+  return map[props.task.status]
+})
+
+const statusDotClass = computed(() => {
+  const map: Record<TaskStatus, string> = {
+    todo: 'bg-gray-400',
+    inprogress: 'bg-blue-500',
+    onhold: 'bg-orange-500',
+    done: 'bg-green-500'
+  }
+  return map[props.task.status]
+})
+
+function statusOptionClass(st: TaskStatus): string {
+  const map: Record<TaskStatus, string> = {
+    todo: 'text-gray-600 dark:text-gray-300',
+    inprogress: 'text-blue-600 dark:text-blue-400',
+    onhold: 'text-orange-600 dark:text-orange-400',
+    done: 'text-green-600 dark:text-green-400'
+  }
+  return map[st]
+}
+
+function statusOptionDotClass(st: TaskStatus): string {
+  const map: Record<TaskStatus, string> = {
+    todo: 'bg-gray-400',
+    inprogress: 'bg-blue-500',
+    onhold: 'bg-orange-500',
+    done: 'bg-green-500'
+  }
+  return map[st]
+}
+
+const priorityDotClass = computed(() => {
+  const map: Record<TaskPriority, string> = {
+    high: 'bg-red-500',
+    medium: 'bg-yellow-400',
+    low: 'bg-gray-300 dark:bg-gray-600'
+  }
+  return map[props.task.priority]
+})
+
+const priorityTextClass = computed(() => {
+  const map: Record<TaskPriority, string> = {
+    high: 'text-red-500',
+    medium: 'text-yellow-500',
+    low: 'text-gray-400'
+  }
+  return map[props.task.priority]
+})
+
+const dropdownAlign = computed(() => {
+  if (!statusWrapper.value) return 'left-0'
+  const rect = statusWrapper.value.getBoundingClientRect()
+  return rect.left + 120 > window.innerWidth ? 'right-0' : 'left-0'
+})
+
+function toggleStatusDropdown() {
+  showStatusDropdown.value = !showStatusDropdown.value
+}
+
+function onStatusChange(st: TaskStatus) {
+  showStatusDropdown.value = false
+  emit('statusChange', props.task.id, st)
+}
+
+function cyclePriority() {
+  const order: TaskPriority[] = ['low', 'medium', 'high']
+  const idx = order.indexOf(props.task.priority)
+  const next = order[(idx + 1) % order.length]
+  emit('priorityChange', props.task.id, next)
+}
+
+function onTitleBlur(e: FocusEvent) {
+  const el = e.target as HTMLElement
+  const newTitle = el.textContent?.trim() || ''
+  if (newTitle !== props.task.title) {
+    emit('update', { ...props.task, title: newTitle })
+  }
+}
+
+function onTitleEscape(e: KeyboardEvent) {
+  const el = e.target as HTMLElement
+  el.textContent = props.task.title
+  el.blur()
+}
+
+function onDescBlur(e: FocusEvent) {
+  const el = e.target as HTMLElement
+  const newDesc = el.textContent?.trim() || ''
+  if (newDesc !== props.task.description) {
+    emit('update', { ...props.task, description: newDesc })
+  }
+}
+
+function onDescEscape(e: KeyboardEvent) {
+  const el = e.target as HTMLElement
+  el.textContent = props.task.description
+  el.blur()
+}
+
+function onDelete() {
+  emit('delete', props.task.id)
+}
+
+// Drag
+function onDragStart(e: DragEvent) {
+  isDragging.value = true
+  e.dataTransfer?.setData('text/plain', props.task.id)
+  emit('dragStart', props.task.id, e)
+}
+
+function onDragEnd() {
+  isDragging.value = false
+  emit('dragEnd')
+}
+
+// Touch drag
+function onTouchStart(e: TouchEvent) {
+  isDragging.value = true
+  emit('touchDrag', props.task.id, e.touches[0].clientX, e.touches[0].clientY, 'start')
+}
+
+function onTouchMove(e: TouchEvent) {
+  emit('touchDrag', props.task.id, e.touches[0].clientX, e.touches[0].clientY, 'move')
+}
+
+function onTouchEnd(e: TouchEvent) {
+  isDragging.value = false
+  emit('touchDrag', props.task.id, e.changedTouches[0].clientX, e.changedTouches[0].clientY, 'end')
+}
+
+// Close dropdown on outside click
+function onOutsideClick(e: MouseEvent) {
+  if (showStatusDropdown.value && statusWrapper.value && !statusWrapper.value.contains(e.target as Node)) {
+    showStatusDropdown.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', onOutsideClick))
+onBeforeUnmount(() => document.removeEventListener('click', onOutsideClick))
+</script>
+
+<style scoped>
+.dropdown-enter-active,
+.dropdown-leave-active {
+  transition: opacity 0.12s, transform 0.12s;
+}
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/src/components/TaskList/TaskCard.vue
+++ b/src/components/TaskList/TaskCard.vue
@@ -11,6 +11,9 @@
     draggable="true"
     @dragstart="onCardDragStart"
     @dragend="onDragEnd"
+    @touchstart="onTouchStart"
+    @touchmove="onTouchMove"
+    @touchend="onTouchEnd"
   >
     <div class="flex items-start justify-between gap-1.5">
       <!-- Priority dot -->
@@ -111,7 +114,7 @@ const emit = defineEmits<{
   statusChange: [taskId: string, status: TaskStatus]
   priorityChange: [taskId: string, priority: TaskPriority]
   update: [task: Task]
-  touchDrag: [taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end']
+  touchDrop: [taskId: string, date: string]
 }>()
 
 const cardEl = ref<HTMLElement>()
@@ -229,13 +232,8 @@ function onDelete() {
   emit('delete', props.task.id)
 }
 
-// Drag — whole card is draggable, prevent on interactive children
+// Desktop drag
 function onCardDragStart(e: DragEvent) {
-  const target = e.target as HTMLElement
-  if (target.classList.contains('editable') || target.closest('.editable') || target.closest('.status-badge') || target.closest('.card-delete')) {
-    e.preventDefault()
-    return
-  }
   isDragging.value = true
   e.dataTransfer?.setData('text/plain', props.task.id)
   emit('dragStart', props.task.id, e)
@@ -244,6 +242,63 @@ function onCardDragStart(e: DragEvent) {
 function onDragEnd() {
   isDragging.value = false
   emit('dragEnd')
+}
+
+// Touch drag with 15px horizontal threshold
+let touchStartX = 0
+let touchClone: HTMLElement | null = null
+
+function onTouchStart(e: TouchEvent) {
+  touchStartX = e.touches[0].clientX
+}
+
+function onTouchMove(e: TouchEvent) {
+  const tx = e.touches[0].clientX
+  const ty = e.touches[0].clientY
+  const dx = Math.abs(tx - touchStartX)
+
+  if (!touchClone && dx > 15) {
+    e.preventDefault()
+    isDragging.value = true
+    touchClone = cardEl.value!.cloneNode(true) as HTMLElement
+    touchClone.style.position = 'fixed'
+    touchClone.style.width = cardEl.value!.offsetWidth + 'px'
+    touchClone.style.opacity = '0.8'
+    touchClone.style.pointerEvents = 'none'
+    touchClone.style.zIndex = '1000'
+    touchClone.style.transform = 'rotate(2deg)'
+    document.body.appendChild(touchClone)
+  }
+
+  if (touchClone) {
+    e.preventDefault()
+    touchClone.style.left = (tx - touchClone.offsetWidth / 2) + 'px'
+    touchClone.style.top = (ty - 20) + 'px'
+    document.querySelectorAll('.day-column').forEach(col => {
+      const r = col.getBoundingClientRect()
+      col.classList.toggle('drag-over', tx >= r.left && tx <= r.right && ty >= r.top && ty <= r.bottom)
+    })
+  }
+}
+
+function onTouchEnd(e: TouchEvent) {
+  isDragging.value = false
+  if (touchClone) {
+    touchClone.remove()
+    touchClone = null
+    const tx = e.changedTouches[0].clientX
+    const ty = e.changedTouches[0].clientY
+    document.querySelectorAll('.day-column').forEach(col => {
+      col.classList.remove('drag-over')
+      const r = col.getBoundingClientRect()
+      if (tx >= r.left && tx <= r.right && ty >= r.top && ty <= r.bottom) {
+        const date = (col as HTMLElement).dataset.date
+        if (date) {
+          emit('touchDrop', props.task.id, date)
+        }
+      }
+    })
+  }
 }
 
 // Close dropdown on outside click

--- a/src/components/TaskList/TaskCard.vue
+++ b/src/components/TaskList/TaskCard.vue
@@ -1,26 +1,26 @@
 <template>
   <div
     ref="cardEl"
-    class="task-card group relative rounded-lg p-3 text-sm transition-all"
+    class="task-card group relative rounded-lg p-3 text-sm transition-all cursor-grab active:cursor-grabbing"
     :class="[
-      task.status === 'done' ? 'opacity-50' : '',
+      task.status === 'done' ? 'opacity-55' : '',
       isDragging ? 'opacity-30' : '',
       bgClass
     ]"
     :data-id="task.id"
+    draggable="true"
+    @dragstart="onCardDragStart"
+    @dragend="onDragEnd"
   >
     <div class="flex items-start justify-between gap-1.5">
-      <!-- Drag handle -->
+      <!-- Priority dot -->
       <span
-        class="drag-handle flex-shrink-0 cursor-grab text-xs leading-none select-none text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity pt-0.5 touch-manipulation"
-        :class="{ 'opacity-50': isMobile }"
-        draggable="true"
-        @dragstart="onDragStart"
-        @dragend="onDragEnd"
-        @touchstart.prevent="onTouchStart"
-        @touchmove.prevent="onTouchMove"
-        @touchend="onTouchEnd"
-      >&#x2807;</span>
+        class="w-[7px] h-[7px] rounded-full flex-shrink-0 mt-1 cursor-pointer transition-transform hover:scale-[1.4]"
+        :class="priorityDotClass"
+        :title="'Priority: ' + task.priority"
+        @click.stop="cyclePriority"
+        @mousedown.stop
+      ></span>
 
       <!-- Title -->
       <span
@@ -34,6 +34,7 @@
         :class="{ 'line-through': task.status === 'done' }"
         :contenteditable="true"
         spellcheck="false"
+        @mousedown.stop
         @blur="onTitleBlur"
         @keydown.enter.prevent="($event.target as HTMLElement).blur()"
         @keydown.escape="onTitleEscape"
@@ -43,6 +44,7 @@
       <button
         class="flex-shrink-0 rounded p-0.5 text-sm leading-none text-transparent group-hover:text-gray-400 hover:!text-red-500 hover:!bg-red-50 dark:hover:!bg-red-900/20 transition-colors"
         title="Delete"
+        @mousedown.stop
         @click="onDelete"
       >&times;</button>
     </div>
@@ -53,6 +55,7 @@
       class="editable mt-1 rounded px-1 py-0.5 -mx-1 text-xs text-gray-500 dark:text-gray-400 leading-relaxed cursor-text hover:bg-black/[0.04] focus:outline-2 focus:outline-primary-500 focus:bg-white dark:focus:bg-gray-800 transition-colors"
       :contenteditable="true"
       spellcheck="false"
+      @mousedown.stop
       @blur="onDescBlur"
       @keydown.enter.prevent="($event.target as HTMLElement).blur()"
       @keydown.escape="onDescEscape"
@@ -65,6 +68,7 @@
         <button
           class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.65rem] font-semibold cursor-pointer select-none border-none transition-all hover:brightness-[0.93] hover:scale-[1.04] active:scale-[0.96]"
           :class="statusBadgeClass"
+          @mousedown.stop
           @click.stop="toggleStatusDropdown"
         >
           <span class="w-[5px] h-[5px] rounded-full flex-shrink-0" :class="statusDotClass"></span>
@@ -73,7 +77,7 @@
         <Transition name="dropdown">
           <div
             v-if="showStatusDropdown"
-            class="absolute top-full mt-1 z-50 min-w-[120px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1"
+            class="absolute bottom-full mb-1 z-50 min-w-[120px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1"
             :class="dropdownAlign"
           >
             <div
@@ -90,15 +94,6 @@
         </Transition>
       </div>
 
-      <!-- Priority dot -->
-      <button
-        class="flex items-center gap-1 text-[0.6rem] font-semibold uppercase tracking-wider cursor-pointer select-none transition-colors"
-        :class="priorityTextClass"
-        @click.stop="cyclePriority"
-        :title="'Priority: ' + task.priority"
-      >
-        <span class="w-[6px] h-[6px] rounded-full" :class="priorityDotClass"></span>
-      </button>
     </div>
   </div>
 </template>
@@ -125,7 +120,6 @@ const descEl = ref<HTMLElement>()
 const statusWrapper = ref<HTMLElement>()
 const showStatusDropdown = ref(false)
 const isDragging = ref(false)
-const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
 
 const bgClass = computed(() => {
   return 'bg-gray-100 dark:bg-gray-800/60 hover:shadow-sm'
@@ -180,14 +174,6 @@ const priorityDotClass = computed(() => {
   return map[props.task.priority]
 })
 
-const priorityTextClass = computed(() => {
-  const map: Record<TaskPriority, string> = {
-    high: 'text-red-500',
-    medium: 'text-yellow-500',
-    low: 'text-gray-400'
-  }
-  return map[props.task.priority]
-})
 
 const dropdownAlign = computed(() => {
   if (!statusWrapper.value) return 'left-0'
@@ -243,8 +229,13 @@ function onDelete() {
   emit('delete', props.task.id)
 }
 
-// Drag
-function onDragStart(e: DragEvent) {
+// Drag — whole card is draggable, prevent on interactive children
+function onCardDragStart(e: DragEvent) {
+  const target = e.target as HTMLElement
+  if (target.classList.contains('editable') || target.closest('.editable') || target.closest('.status-badge') || target.closest('.card-delete')) {
+    e.preventDefault()
+    return
+  }
   isDragging.value = true
   e.dataTransfer?.setData('text/plain', props.task.id)
   emit('dragStart', props.task.id, e)
@@ -253,21 +244,6 @@ function onDragStart(e: DragEvent) {
 function onDragEnd() {
   isDragging.value = false
   emit('dragEnd')
-}
-
-// Touch drag
-function onTouchStart(e: TouchEvent) {
-  isDragging.value = true
-  emit('touchDrag', props.task.id, e.touches[0].clientX, e.touches[0].clientY, 'start')
-}
-
-function onTouchMove(e: TouchEvent) {
-  emit('touchDrag', props.task.id, e.touches[0].clientX, e.touches[0].clientY, 'move')
-}
-
-function onTouchEnd(e: TouchEvent) {
-  isDragging.value = false
-  emit('touchDrag', props.task.id, e.changedTouches[0].clientX, e.changedTouches[0].clientY, 'end')
 }
 
 // Close dropdown on outside click

--- a/src/components/TaskList/UndoToast.vue
+++ b/src/components/TaskList/UndoToast.vue
@@ -1,0 +1,40 @@
+<template>
+  <Teleport to="body">
+    <TransitionGroup name="toast" tag="div" class="fixed bottom-6 right-6 z-[200] flex flex-col gap-2">
+      <div
+        v-for="entry in store.undoStack"
+        :key="entry.task.id + entry.type"
+        class="flex items-center gap-3 rounded-lg bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2.5 shadow-lg text-sm"
+      >
+        <span v-if="entry.type === 'delete'">Deleted "{{ entry.task.title }}"</span>
+        <span v-else>Changed to {{ STATUS_LABELS[entry.task.status] }}</span>
+        <button
+          class="font-semibold text-primary-400 dark:text-primary-600 hover:underline"
+          @click="store.undo(entry)"
+        >Undo</button>
+      </div>
+    </TransitionGroup>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useTaskListStore } from '@/stores/taskList'
+import { STATUS_LABELS } from '@/views/TaskList/types'
+
+const store = useTaskListStore()
+</script>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.25s ease;
+}
+.toast-enter-from {
+  opacity: 0;
+  transform: translateY(16px);
+}
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(32px);
+}
+</style>

--- a/src/components/TaskList/WeekGrid.vue
+++ b/src/components/TaskList/WeekGrid.vue
@@ -29,7 +29,7 @@
         @status-change="(id, st) => store.changeStatus(id, st)"
         @priority-change="(id, p) => store.changePriority(id, p)"
         @update="t => store.updateTask(t)"
-        @touch-drag="onTouchDrag"
+        @touch-drop="onTouchDrop"
       />
     </div>
 
@@ -142,25 +142,8 @@ function onDrop(taskId: string, date: string, insertBeforeId?: string) {
   store.moveTask(taskId, date, insertBeforeId)
 }
 
-// Touch drag — simplified version
-let touchTaskId: string | null = null
-function onTouchDrag(taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end') {
-  if (phase === 'start') {
-    touchTaskId = taskId
-  } else if (phase === 'end' && touchTaskId) {
-    // Find which column we're over
-    const columns = document.querySelectorAll('.day-column')
-    for (const col of columns) {
-      const rect = col.getBoundingClientRect()
-      if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-        const date = (col as HTMLElement).dataset.date
-        if (date) {
-          store.moveTask(touchTaskId, date)
-        }
-        break
-      }
-    }
-    touchTaskId = null
-  }
+// Touch drop — card handles the drag visuals, we just move the task
+function onTouchDrop(taskId: string, date: string) {
+  store.moveTask(taskId, date)
 }
 </script>

--- a/src/components/TaskList/WeekGrid.vue
+++ b/src/components/TaskList/WeekGrid.vue
@@ -1,0 +1,181 @@
+<template>
+  <div>
+    <!-- Week navigation -->
+    <div class="flex items-center gap-2 mb-5">
+      <button class="px-2.5 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" @click="prevWeek">&larr;</button>
+      <span class="text-sm font-semibold text-gray-500 dark:text-gray-400 min-w-[160px] text-center">{{ weekLabel }}</span>
+      <button class="px-2.5 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" @click="nextWeek">&rarr;</button>
+      <button class="ml-1 px-2.5 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" @click="goToday">Today</button>
+    </div>
+
+    <!-- Grid -->
+    <div
+      class="grid gap-2.5 mb-5"
+      :class="isMobile ? 'flex overflow-x-auto snap-x snap-mandatory pb-2 -mx-3 px-3' : 'grid-cols-7'"
+    >
+      <DayColumn
+        v-for="date in weekDates"
+        :key="date"
+        :date="date"
+        :day-tasks="store.tasksForDate(date)"
+        :is-today="date === today"
+        :is-mobile="isMobile"
+        :style="isMobile && date === today ? { order: -1 } : {}"
+        @add-task="d => store.addTask(d)"
+        @drop="onDrop"
+        @drag-start="onDragStart"
+        @drag-end="onDragEnd"
+        @delete="id => store.deleteTask(id)"
+        @status-change="(id, st) => store.changeStatus(id, st)"
+        @priority-change="(id, p) => store.changePriority(id, p)"
+        @update="t => store.updateTask(t)"
+        @touch-drag="onTouchDrag"
+      />
+    </div>
+
+    <!-- On Hold section -->
+    <div v-if="store.onHoldTasks.length > 0" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 mb-5">
+      <div class="text-xs font-semibold uppercase tracking-wider text-orange-600 dark:text-orange-400 mb-2 flex items-center gap-1.5">
+        <span class="w-[7px] h-[7px] rounded-full bg-orange-500"></span> On Hold
+      </div>
+      <div class="flex flex-wrap gap-2" :class="{ 'flex-col': isMobile }">
+        <div v-for="task in store.onHoldTasks" :key="task.id" :class="isMobile ? 'w-full' : 'w-60'">
+          <TaskCard
+            :task="task"
+            @delete="id => store.deleteTask(id)"
+            @status-change="(id, st) => store.changeStatus(id, st)"
+            @priority-change="(id, p) => store.changePriority(id, p)"
+            @update="t => store.updateTask(t)"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Done section -->
+    <div v-if="store.doneTasks.length > 0" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+      <div class="text-xs font-semibold uppercase tracking-wider text-green-600 dark:text-green-400 mb-2 flex items-center gap-1.5">
+        <span class="w-[7px] h-[7px] rounded-full bg-green-500"></span> Done
+      </div>
+      <div class="flex flex-wrap gap-2" :class="{ 'flex-col': isMobile }">
+        <div v-for="task in store.doneTasks" :key="task.id" :class="isMobile ? 'w-full' : 'w-60'" class="opacity-55">
+          <TaskCard
+            :task="task"
+            @delete="id => store.deleteTask(id)"
+            @status-change="(id, st) => store.changeStatus(id, st)"
+            @priority-change="(id, p) => store.changePriority(id, p)"
+            @update="t => store.updateTask(t)"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useTaskListStore } from '@/stores/taskList'
+import DayColumn from './DayColumn.vue'
+import TaskCard from './TaskCard.vue'
+
+const store = useTaskListStore()
+
+const currentMonday = ref(getMonday(new Date()))
+const isMobile = ref(false)
+
+function checkMobile() {
+  isMobile.value = window.innerWidth < 768
+}
+
+onMounted(() => {
+  checkMobile()
+  window.addEventListener('resize', checkMobile)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkMobile)
+})
+
+function getMonday(d: Date): Date {
+  const dt = new Date(d)
+  const day = dt.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  dt.setDate(dt.getDate() + diff)
+  dt.setHours(0, 0, 0, 0)
+  return dt
+}
+
+function toDateStr(d: Date): string {
+  return d.getFullYear() + '-' +
+    String(d.getMonth() + 1).padStart(2, '0') + '-' +
+    String(d.getDate()).padStart(2, '0')
+}
+
+const today = computed(() => toDateStr(new Date()))
+
+const weekDates = computed(() => {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(currentMonday.value)
+    d.setDate(d.getDate() + i)
+    return toDateStr(d)
+  })
+})
+
+const weekLabel = computed(() => {
+  const mon = currentMonday.value
+  const sun = new Date(mon)
+  sun.setDate(sun.getDate() + 6)
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+  return mon.toLocaleDateString('en-GB', opts) + ' — ' + sun.toLocaleDateString('en-GB', opts) + ', ' + sun.getFullYear()
+})
+
+function prevWeek() {
+  const d = new Date(currentMonday.value)
+  d.setDate(d.getDate() - 7)
+  currentMonday.value = d
+}
+
+function nextWeek() {
+  const d = new Date(currentMonday.value)
+  d.setDate(d.getDate() + 7)
+  currentMonday.value = d
+}
+
+function goToday() {
+  currentMonday.value = getMonday(new Date())
+}
+
+// Drag handling
+function onDragStart(_taskId: string, _e: DragEvent) {
+  // handled by TaskCard
+}
+
+function onDragEnd() {
+  // cleanup
+}
+
+function onDrop(taskId: string, date: string, insertBeforeId?: string) {
+  store.moveTask(taskId, date, insertBeforeId)
+}
+
+// Touch drag — simplified version
+let touchTaskId: string | null = null
+function onTouchDrag(taskId: string, x: number, y: number, phase: 'start' | 'move' | 'end') {
+  if (phase === 'start') {
+    touchTaskId = taskId
+  } else if (phase === 'end' && touchTaskId) {
+    // Find which column we're over
+    const columns = document.querySelectorAll('.day-column')
+    for (const col of columns) {
+      const rect = col.getBoundingClientRect()
+      if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+        const date = (col as HTMLElement).dataset.date
+        if (date) {
+          store.moveTask(touchTaskId, date)
+        }
+        break
+      }
+    }
+    touchTaskId = null
+  }
+}
+</script>

--- a/src/components/TaskList/WeekGrid.vue
+++ b/src/components/TaskList/WeekGrid.vue
@@ -11,7 +11,7 @@
     <!-- Grid -->
     <div
       class="grid gap-2.5 mb-5"
-      :class="isMobile ? 'flex overflow-x-auto snap-x snap-mandatory pb-2 -mx-3 px-3' : 'grid-cols-7'"
+      :class="isTablet ? 'flex overflow-x-auto snap-x snap-mandatory pb-2 -mx-3 px-3' : 'grid-cols-7'"
     >
       <DayColumn
         v-for="date in weekDates"
@@ -19,8 +19,8 @@
         :date="date"
         :day-tasks="store.tasksForDate(date)"
         :is-today="date === today"
-        :is-mobile="isMobile"
-        :style="isMobile && date === today ? { order: -1 } : {}"
+        :is-mobile="isTablet"
+        :style="isTablet && date === today ? { order: -1 } : {}"
         @add-task="d => store.addTask(d)"
         @drop="onDrop"
         @drag-start="onDragStart"
@@ -39,7 +39,7 @@
         <span class="w-[7px] h-[7px] rounded-full bg-orange-500"></span> On Hold
       </div>
       <div class="flex flex-wrap gap-2" :class="{ 'flex-col': isMobile }">
-        <div v-for="task in store.onHoldTasks" :key="task.id" :class="isMobile ? 'w-full' : 'w-60'">
+        <div v-for="task in store.onHoldTasks" :key="task.id" :class="isMobile ? 'w-full' : 'w-60'" class="flex-shrink-0">
           <TaskCard
             :task="task"
             @delete="id => store.deleteTask(id)"
@@ -51,23 +51,6 @@
       </div>
     </div>
 
-    <!-- Done section -->
-    <div v-if="store.doneTasks.length > 0" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
-      <div class="text-xs font-semibold uppercase tracking-wider text-green-600 dark:text-green-400 mb-2 flex items-center gap-1.5">
-        <span class="w-[7px] h-[7px] rounded-full bg-green-500"></span> Done
-      </div>
-      <div class="flex flex-wrap gap-2" :class="{ 'flex-col': isMobile }">
-        <div v-for="task in store.doneTasks" :key="task.id" :class="isMobile ? 'w-full' : 'w-60'" class="opacity-55">
-          <TaskCard
-            :task="task"
-            @delete="id => store.deleteTask(id)"
-            @status-change="(id, st) => store.changeStatus(id, st)"
-            @priority-change="(id, p) => store.changePriority(id, p)"
-            @update="t => store.updateTask(t)"
-          />
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -81,9 +64,11 @@ const store = useTaskListStore()
 
 const currentMonday = ref(getMonday(new Date()))
 const isMobile = ref(false)
+const isTablet = ref(false)
 
 function checkMobile() {
   isMobile.value = window.innerWidth < 768
+  isTablet.value = window.innerWidth <= 1024
 }
 
 onMounted(() => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -23,6 +23,10 @@
     "welcome": "Welcome to MyApps",
     "subtitle": "A collection of useful applications"
   },
+  "taskList": {
+    "title": "Task List",
+    "subtitle": "Plan your week, track your tasks"
+  },
   "readTracker": {
     "title": "📚 Read Tracker",
     "subtitle": "Track your reading time and build better reading habits",
@@ -118,6 +122,11 @@
     "portfolioTracker": {
       "name": "Portfolio Tracker",
       "description": "Manage your stock portfolio, track live prices, and monitor your investment performance.",
+      "openApp": "Open App"
+    },
+    "taskList": {
+      "name": "Task List",
+      "description": "Plan your week with a visual task board. Drag, drop, and track progress.",
       "openApp": "Open App"
     },
     "signIn": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -23,6 +23,10 @@
     "welcome": "Chào mừng đến với MyApps",
     "subtitle": "Bộ sưu tập các ứng dụng hữu ích"
   },
+  "taskList": {
+    "title": "Danh sách công việc",
+    "subtitle": "Lên kế hoạch tuần, theo dõi công việc"
+  },
   "readTracker": {
     "title": "📚 Read Tracker",
     "subtitle": "Theo dõi thời gian đọc sách và xây dựng thói quen đọc tốt hơn",
@@ -118,6 +122,11 @@
     "portfolioTracker": {
       "name": "Portfolio Tracker",
       "description": "Quản lý danh mục cổ phiếu, theo dõi giá trực tiếp và giám sát hiệu suất đầu tư của bạn.",
+      "openApp": "Mở ứng dụng"
+    },
+    "taskList": {
+      "name": "Danh sách công việc",
+      "description": "Lên kế hoạch tuần với bảng công việc trực quan. Kéo, thả và theo dõi tiến độ.",
       "openApp": "Mở ứng dụng"
     },
     "signIn": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import Home from '@/views/Home.vue'
 import ReadTrackerLayout from '@/views/ReadTracker/ReadTrackerLayout.vue'
 import PortfolioTrackerLayout from '@/views/PortfolioTracker/PortfolioTrackerLayout.vue'
+import TaskListLayout from '@/views/TaskList/TaskListLayout.vue'
 import { useAuthStore } from '@/stores/auth'
 
 const routes: RouteRecordRaw[] = [
@@ -82,6 +83,23 @@ const routes: RouteRecordRaw[] = [
         path: 'settings',
         name: 'portfolio-tracker-settings',
         component: () => import('@/views/PortfolioTracker/Settings.vue')
+      }
+    ]
+  },
+  {
+    path: '/task-list',
+    component: TaskListLayout,
+    meta: { requiresAuth: true },
+    children: [
+      {
+        path: '',
+        name: 'task-list',
+        redirect: '/task-list/dashboard'
+      },
+      {
+        path: 'dashboard',
+        name: 'task-list-dashboard',
+        component: () => import('@/views/TaskList/Dashboard.vue')
       }
     ]
   }

--- a/src/stores/taskList.ts
+++ b/src/stores/taskList.ts
@@ -52,16 +52,16 @@ export const useTaskListStore = defineStore('taskList', () => {
   }
 
   // ── Carry forward: move overdue todo/inprogress tasks to today ──
-  function carryForward(): boolean {
+  function carryForward(): Task[] {
     const today = todayStr()
-    let moved = false
+    const movedTasks: Task[] = []
     tasks.value.forEach(t => {
       if ((t.status === 'todo' || t.status === 'inprogress') && t.date < today) {
         t.date = today
-        moved = true
+        movedTasks.push(t)
       }
     })
-    return moved
+    return movedTasks
   }
 
   // ── Local storage ──
@@ -86,34 +86,37 @@ export const useTaskListStore = defineStore('taskList', () => {
     try {
       const q = query(getCollection(), orderBy('createdAt', 'desc'))
       const snapshot = await getDocs(q)
-      tasks.value = snapshot.docs.map(d => {
-        const data = d.data()
-        return {
-          id: d.id,
-          title: data.title ?? '',
-          description: data.description ?? '',
-          status: data.status ?? 'todo',
-          priority: data.priority ?? 'medium',
-          date: data.date ?? todayStr(),
-          tag: data.tag ?? false,
-          createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? undefined,
-          updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? undefined
-        } as Task
-      })
+      tasks.value = snapshot.docs
+        .filter(d => !d.data()._deleted)
+        .map(d => {
+          const data = d.data()
+          return {
+            id: d.id,
+            title: data.title ?? '',
+            description: data.description ?? '',
+            status: data.status ?? 'todo',
+            priority: data.priority ?? 'medium',
+            date: data.date ?? todayStr(),
+            tag: data.tag ?? false,
+            createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? undefined,
+            updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? undefined
+          } as Task
+        })
     } finally {
       loading.value = false
     }
   }
 
   async function saveTaskToFirestore(task: Task) {
-    const ref = doc(db, `users/${userId.value}/tasks/${task.id}`)
-    await updateDoc(ref, {
+    const taskRef = doc(db, `users/${userId.value}/tasks/${task.id}`)
+    await updateDoc(taskRef, {
       title: task.title,
       description: task.description,
       status: task.status,
       priority: task.priority,
       date: task.date,
       tag: task.tag,
+      _deleted: task._deleted ?? false,
       updatedAt: Timestamp.now()
     })
   }
@@ -126,21 +129,21 @@ export const useTaskListStore = defineStore('taskList', () => {
     } else {
       await loadFromFirestore()
     }
-    if (carryForward()) {
-      await saveAll()
+    const movedTasks = carryForward()
+    if (movedTasks.length > 0) {
+      await saveTasks(movedTasks)
     }
   }
 
-  async function saveAll() {
+  async function saveTasks(changedTasks: Task[]) {
     if (isLocal.value) {
       saveLocal()
       return
     }
-    // Batch update all tasks that were carried forward
     const batch = writeBatch(db)
-    for (const task of tasks.value) {
-      const ref = doc(db, `users/${userId.value}/tasks/${task.id}`)
-      batch.update(ref, { date: task.date, updatedAt: Timestamp.now() })
+    for (const task of changedTasks) {
+      const taskRef = doc(db, `users/${userId.value}/tasks/${task.id}`)
+      batch.update(taskRef, { date: task.date, updatedAt: Timestamp.now() })
     }
     await batch.commit()
   }
@@ -193,17 +196,42 @@ export const useTaskListStore = defineStore('taskList', () => {
     const idx = tasks.value.findIndex(t => t.id === taskId)
     if (idx === -1) return
 
-    const task = { ...tasks.value[idx] }
-    tasks.value.splice(idx, 1)
+    const task = tasks.value[idx]
 
+    if (withUndo) {
+      // Soft-delete: hide from UI, keep in Firestore until undo window expires
+      task._deleted = true
+      if (isLocal.value) {
+        saveLocal()
+      } else {
+        await saveTaskToFirestore(task)
+      }
+
+      pushUndo({
+        type: 'delete',
+        task: { ...task },
+        timer: setTimeout(() => commitDelete(taskId), 5000)
+      })
+    } else {
+      // Hard delete (called after undo window or explicitly)
+      tasks.value.splice(idx, 1)
+      if (isLocal.value) {
+        saveLocal()
+      } else {
+        await deleteDoc(doc(db, `users/${userId.value}/tasks/${taskId}`))
+      }
+    }
+  }
+
+  async function commitDelete(taskId: string) {
+    removeUndo('delete', taskId)
+    const idx = tasks.value.findIndex(t => t.id === taskId)
+    if (idx === -1) return
+    tasks.value.splice(idx, 1)
     if (isLocal.value) {
       saveLocal()
     } else {
       await deleteDoc(doc(db, `users/${userId.value}/tasks/${taskId}`))
-    }
-
-    if (withUndo) {
-      pushUndo({ type: 'delete', task, timer: setTimeout(() => removeUndo('delete', task.id), 5000) })
     }
   }
 
@@ -275,23 +303,15 @@ export const useTaskListStore = defineStore('taskList', () => {
     if (idx !== -1) undoStack.value.splice(idx, 1)
 
     if (entry.type === 'delete') {
-      // Re-add the task
-      if (isLocal.value) {
-        tasks.value.push(entry.task)
-        saveLocal()
-      } else {
-        const docRef = await addDoc(getCollection(), {
-          title: entry.task.title,
-          description: entry.task.description,
-          status: entry.task.status,
-          priority: entry.task.priority,
-          date: entry.task.date,
-          tag: entry.task.tag,
-          createdAt: Timestamp.now(),
-          updatedAt: Timestamp.now()
-        })
-        entry.task.id = docRef.id
-        tasks.value.push(entry.task)
+      // Restore soft-deleted task
+      const task = tasks.value.find(t => t.id === entry.task.id)
+      if (task) {
+        delete task._deleted
+        if (isLocal.value) {
+          saveLocal()
+        } else {
+          await saveTaskToFirestore(task)
+        }
       }
     } else if (entry.type === 'status' && entry.previousStatus) {
       const task = tasks.value.find(t => t.id === entry.task.id)
@@ -305,15 +325,15 @@ export const useTaskListStore = defineStore('taskList', () => {
   // ── Queries ──
   function tasksForDate(date: string): Task[] {
     return tasks.value
-      .filter(t => t.date === date && t.status !== 'done' && t.status !== 'onhold')
+      .filter(t => !t._deleted && t.date === date && t.status !== 'done' && t.status !== 'onhold')
       .sort((a, b) => {
         const order: Record<string, number> = { inprogress: 0, todo: 1 }
         return (order[a.status] ?? 1) - (order[b.status] ?? 1)
       })
   }
 
-  const onHoldTasks = computed(() => tasks.value.filter(t => t.status === 'onhold'))
-  const doneTasks = computed(() => tasks.value.filter(t => t.status === 'done'))
+  const onHoldTasks = computed(() => tasks.value.filter(t => !t._deleted && t.status === 'onhold'))
+  const doneTasks = computed(() => tasks.value.filter(t => !t._deleted && t.status === 'done'))
 
   return {
     tasks,

--- a/src/stores/taskList.ts
+++ b/src/stores/taskList.ts
@@ -305,15 +305,14 @@ export const useTaskListStore = defineStore('taskList', () => {
   // ── Queries ──
   function tasksForDate(date: string): Task[] {
     return tasks.value
-      .filter(t => t.date === date && t.status !== 'done' && t.status !== 'onhold')
+      .filter(t => t.date === date && t.status !== 'onhold')
       .sort((a, b) => {
-        const order: Record<string, number> = { inprogress: 0, todo: 1 }
+        const order: Record<string, number> = { inprogress: 0, todo: 1, done: 2 }
         return (order[a.status] ?? 1) - (order[b.status] ?? 1)
       })
   }
 
   const onHoldTasks = computed(() => tasks.value.filter(t => t.status === 'onhold'))
-  const doneTasks = computed(() => tasks.value.filter(t => t.status === 'done'))
 
   return {
     tasks,
@@ -329,7 +328,6 @@ export const useTaskListStore = defineStore('taskList', () => {
     undo,
     tasksForDate,
     onHoldTasks,
-    doneTasks,
     todayStr
   }
 })

--- a/src/stores/taskList.ts
+++ b/src/stores/taskList.ts
@@ -1,0 +1,335 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './auth'
+import { db } from '@/firebase/config'
+import {
+  collection,
+  doc,
+  getDocs,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  orderBy,
+  Timestamp,
+  writeBatch
+} from 'firebase/firestore'
+import type { Task, TaskStatus, TaskPriority } from '@/views/TaskList/types'
+
+const LOCAL_STORAGE_KEY = 'taskList_tasks'
+
+interface UndoEntry {
+  type: 'delete' | 'status'
+  task: Task
+  previousStatus?: TaskStatus
+  timer: ReturnType<typeof setTimeout>
+}
+
+export const useTaskListStore = defineStore('taskList', () => {
+  const authStore = useAuthStore()
+
+  const tasks = ref<Task[]>([])
+  const loading = ref(false)
+  const undoStack = ref<UndoEntry[]>([])
+
+  const userId = computed(() => authStore.user?.uid ?? null)
+  const isLocal = computed(() => authStore.localMode)
+
+  function getCollection() {
+    if (!userId.value) throw new Error('Not authenticated')
+    return collection(db, `users/${userId.value}/tasks`)
+  }
+
+  // ── Date helpers ──
+  function toDateStr(d: Date): string {
+    return d.getFullYear() + '-' +
+      String(d.getMonth() + 1).padStart(2, '0') + '-' +
+      String(d.getDate()).padStart(2, '0')
+  }
+
+  function todayStr(): string {
+    return toDateStr(new Date())
+  }
+
+  // ── Carry forward: move overdue todo/inprogress tasks to today ──
+  function carryForward(): boolean {
+    const today = todayStr()
+    let moved = false
+    tasks.value.forEach(t => {
+      if ((t.status === 'todo' || t.status === 'inprogress') && t.date < today) {
+        t.date = today
+        moved = true
+      }
+    })
+    return moved
+  }
+
+  // ── Local storage ──
+  function saveLocal() {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(tasks.value))
+  }
+
+  function loadLocal() {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY)
+    if (raw) {
+      try {
+        tasks.value = JSON.parse(raw)
+      } catch {
+        tasks.value = []
+      }
+    }
+  }
+
+  // ── Firestore ──
+  async function loadFromFirestore() {
+    loading.value = true
+    try {
+      const q = query(getCollection(), orderBy('createdAt', 'desc'))
+      const snapshot = await getDocs(q)
+      tasks.value = snapshot.docs.map(d => {
+        const data = d.data()
+        return {
+          id: d.id,
+          title: data.title ?? '',
+          description: data.description ?? '',
+          status: data.status ?? 'todo',
+          priority: data.priority ?? 'medium',
+          date: data.date ?? todayStr(),
+          tag: data.tag ?? false,
+          createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? undefined,
+          updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? undefined
+        } as Task
+      })
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function saveTaskToFirestore(task: Task) {
+    const ref = doc(db, `users/${userId.value}/tasks/${task.id}`)
+    await updateDoc(ref, {
+      title: task.title,
+      description: task.description,
+      status: task.status,
+      priority: task.priority,
+      date: task.date,
+      tag: task.tag,
+      updatedAt: Timestamp.now()
+    })
+  }
+
+  // ── Public API ──
+
+  async function load() {
+    if (isLocal.value) {
+      loadLocal()
+    } else {
+      await loadFromFirestore()
+    }
+    if (carryForward()) {
+      await saveAll()
+    }
+  }
+
+  async function saveAll() {
+    if (isLocal.value) {
+      saveLocal()
+      return
+    }
+    // Batch update all tasks that were carried forward
+    const batch = writeBatch(db)
+    for (const task of tasks.value) {
+      const ref = doc(db, `users/${userId.value}/tasks/${task.id}`)
+      batch.update(ref, { date: task.date, updatedAt: Timestamp.now() })
+    }
+    await batch.commit()
+  }
+
+  async function addTask(date: string): Promise<Task> {
+    const now = new Date().toISOString()
+    const newTask: Task = {
+      id: 'task-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6),
+      title: 'New task',
+      description: '',
+      status: 'todo',
+      priority: 'medium',
+      date,
+      tag: false,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    if (isLocal.value) {
+      tasks.value.push(newTask)
+      saveLocal()
+    } else {
+      const docRef = await addDoc(getCollection(), {
+        title: newTask.title,
+        description: newTask.description,
+        status: newTask.status,
+        priority: newTask.priority,
+        date: newTask.date,
+        tag: newTask.tag,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+      })
+      newTask.id = docRef.id
+      tasks.value.push(newTask)
+    }
+
+    return newTask
+  }
+
+  async function updateTask(task: Task) {
+    task.updatedAt = new Date().toISOString()
+    if (isLocal.value) {
+      saveLocal()
+    } else {
+      await saveTaskToFirestore(task)
+    }
+  }
+
+  async function deleteTask(taskId: string, withUndo = true) {
+    const idx = tasks.value.findIndex(t => t.id === taskId)
+    if (idx === -1) return
+
+    const task = { ...tasks.value[idx] }
+    tasks.value.splice(idx, 1)
+
+    if (isLocal.value) {
+      saveLocal()
+    } else {
+      await deleteDoc(doc(db, `users/${userId.value}/tasks/${taskId}`))
+    }
+
+    if (withUndo) {
+      pushUndo({ type: 'delete', task, timer: setTimeout(() => removeUndo('delete', task.id), 5000) })
+    }
+  }
+
+  async function changeStatus(taskId: string, newStatus: TaskStatus) {
+    const task = tasks.value.find(t => t.id === taskId)
+    if (!task) return
+
+    const previousStatus = task.status
+    task.status = newStatus
+    await updateTask(task)
+
+    pushUndo({
+      type: 'status',
+      task: { ...task },
+      previousStatus,
+      timer: setTimeout(() => removeUndo('status', task.id), 5000)
+    })
+  }
+
+  async function changePriority(taskId: string, newPriority: TaskPriority) {
+    const task = tasks.value.find(t => t.id === taskId)
+    if (!task) return
+    task.priority = newPriority
+    await updateTask(task)
+  }
+
+  async function moveTask(taskId: string, newDate: string, insertBeforeId?: string) {
+    const task = tasks.value.find(t => t.id === taskId)
+    if (!task) return
+
+    task.date = newDate
+
+    // Reorder in array
+    const filtered = tasks.value.filter(t => t.id !== taskId)
+    if (insertBeforeId) {
+      const targetIdx = filtered.findIndex(t => t.id === insertBeforeId)
+      if (targetIdx !== -1) {
+        filtered.splice(targetIdx, 0, task)
+      } else {
+        filtered.push(task)
+      }
+    } else {
+      filtered.push(task)
+    }
+    tasks.value = filtered
+
+    await updateTask(task)
+  }
+
+  // ── Undo system ──
+  function pushUndo(entry: UndoEntry) {
+    // Only keep latest per task
+    const existing = undoStack.value.findIndex(u => u.task.id === entry.task.id)
+    if (existing !== -1) {
+      clearTimeout(undoStack.value[existing].timer)
+      undoStack.value.splice(existing, 1)
+    }
+    undoStack.value.push(entry)
+  }
+
+  function removeUndo(type: string, taskId: string) {
+    const idx = undoStack.value.findIndex(u => u.type === type && u.task.id === taskId)
+    if (idx !== -1) undoStack.value.splice(idx, 1)
+  }
+
+  async function undo(entry: UndoEntry) {
+    clearTimeout(entry.timer)
+    const idx = undoStack.value.indexOf(entry)
+    if (idx !== -1) undoStack.value.splice(idx, 1)
+
+    if (entry.type === 'delete') {
+      // Re-add the task
+      if (isLocal.value) {
+        tasks.value.push(entry.task)
+        saveLocal()
+      } else {
+        const docRef = await addDoc(getCollection(), {
+          title: entry.task.title,
+          description: entry.task.description,
+          status: entry.task.status,
+          priority: entry.task.priority,
+          date: entry.task.date,
+          tag: entry.task.tag,
+          createdAt: Timestamp.now(),
+          updatedAt: Timestamp.now()
+        })
+        entry.task.id = docRef.id
+        tasks.value.push(entry.task)
+      }
+    } else if (entry.type === 'status' && entry.previousStatus) {
+      const task = tasks.value.find(t => t.id === entry.task.id)
+      if (task) {
+        task.status = entry.previousStatus
+        await updateTask(task)
+      }
+    }
+  }
+
+  // ── Queries ──
+  function tasksForDate(date: string): Task[] {
+    return tasks.value
+      .filter(t => t.date === date && t.status !== 'done' && t.status !== 'onhold')
+      .sort((a, b) => {
+        const order: Record<string, number> = { inprogress: 0, todo: 1 }
+        return (order[a.status] ?? 1) - (order[b.status] ?? 1)
+      })
+  }
+
+  const onHoldTasks = computed(() => tasks.value.filter(t => t.status === 'onhold'))
+  const doneTasks = computed(() => tasks.value.filter(t => t.status === 'done'))
+
+  return {
+    tasks,
+    loading,
+    undoStack,
+    load,
+    addTask,
+    updateTask,
+    deleteTask,
+    changeStatus,
+    changePriority,
+    moveTask,
+    undo,
+    tasksForDate,
+    onHoldTasks,
+    doneTasks,
+    todayStr
+  }
+})

--- a/src/views/Home.spec.ts
+++ b/src/views/Home.spec.ts
@@ -21,6 +21,6 @@ describe('Home', () => {
   it('shows Open App buttons for each app', async () => {
     const { findAllByRole } = renderWithProviders(Home)
     const buttons = await findAllByRole('button', { name: /open app/i })
-    expect(buttons.length).toBe(2)
+    expect(buttons.length).toBe(3)
   })
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -64,6 +64,13 @@ const apps = ref<App[]>([
     description: t('home.portfolioTracker.description'),
     icon: '📈',
     route: '/portfolio-tracker'
+  },
+  {
+    id: 'task-list',
+    name: t('home.taskList.name'),
+    description: t('home.taskList.description'),
+    icon: '📋',
+    route: '/task-list'
   }
 ])
 

--- a/src/views/TaskList/Dashboard.vue
+++ b/src/views/TaskList/Dashboard.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <div v-if="store.loading" class="flex items-center justify-center py-16">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    </div>
+    <WeekGrid v-else />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useTaskListStore } from '@/stores/taskList'
+import WeekGrid from '@/components/TaskList/WeekGrid.vue'
+
+const store = useTaskListStore()
+
+onMounted(() => {
+  store.load()
+})
+</script>

--- a/src/views/TaskList/TaskListLayout.vue
+++ b/src/views/TaskList/TaskListLayout.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="w-full">
+    <LocalModeWarning />
+
+    <div class="mb-4 sm:mb-6 lg:mb-8 flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-1">{{ $t('taskList.title') }}</h1>
+        <p class="text-sm sm:text-base text-gray-600 dark:text-gray-400">{{ $t('taskList.subtitle') }}</p>
+      </div>
+      <button
+        class="p-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        title="Toggle dark mode"
+        @click="toggleDark"
+      >
+        <span v-if="isDark">&#9728;</span>
+        <span v-else>&#9790;</span>
+      </button>
+    </div>
+
+    <div class="min-h-[400px]">
+      <router-view />
+    </div>
+
+    <UndoToast />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import LocalModeWarning from '@/components/common/LocalModeWarning.vue'
+import UndoToast from '@/components/TaskList/UndoToast.vue'
+
+const isDark = ref(false)
+
+function toggleDark() {
+  isDark.value = !isDark.value
+  document.documentElement.classList.toggle('dark', isDark.value)
+  localStorage.setItem('taskList_darkMode', isDark.value ? 'true' : 'false')
+}
+
+onMounted(() => {
+  const stored = localStorage.getItem('taskList_darkMode')
+  if (stored === 'true' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    isDark.value = true
+    document.documentElement.classList.add('dark')
+  }
+})
+</script>

--- a/src/views/TaskList/types.ts
+++ b/src/views/TaskList/types.ts
@@ -11,6 +11,7 @@ export interface Task {
   tag: boolean
   createdAt?: string
   updatedAt?: string
+  _deleted?: boolean
 }
 
 export const STATUS_ORDER: TaskStatus[] = ['todo', 'inprogress', 'onhold', 'done']

--- a/src/views/TaskList/types.ts
+++ b/src/views/TaskList/types.ts
@@ -1,0 +1,31 @@
+export type TaskStatus = 'todo' | 'inprogress' | 'onhold' | 'done'
+export type TaskPriority = 'high' | 'medium' | 'low'
+
+export interface Task {
+  id: string
+  title: string
+  description: string
+  status: TaskStatus
+  priority: TaskPriority
+  date: string // YYYY-MM-DD
+  tag: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export const STATUS_ORDER: TaskStatus[] = ['todo', 'inprogress', 'onhold', 'done']
+
+export const STATUS_LABELS: Record<TaskStatus, string> = {
+  todo: 'To Do',
+  inprogress: 'In Progress',
+  onhold: 'On Hold',
+  done: 'Done'
+}
+
+export const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low'
+}
+
+export const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{vue,js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- Migrates standalone tasklist (Fly.io/Node.js) into the myapps Vue 3 platform
- Weekly calendar grid with 7-day view, week navigation, and today highlight
- Task cards with drag-and-drop (desktop + touch), inline editing, status workflow (To Do / In Progress / On Hold / Done)
- Priority dots (high/medium/low) with click-to-cycle
- Carry-forward of overdue tasks to today
- Undo toast for delete and status changes
- Dark mode via Tailwind class strategy
- Card add/remove transitions
- Firestore-backed Pinia store with local mode fallback
- i18n (en + vi), responsive mobile layout
- Home page card added

## Files
- `src/views/TaskList/` — Layout, Dashboard, types
- `src/components/TaskList/` — WeekGrid, DayColumn, TaskCard, UndoToast
- `src/stores/taskList.ts` — Pinia store with Firestore + local storage
- Router, Home.vue, i18n, tailwind config updated

## Test plan
- [x] Type check passes (vue-tsc)
- [x] Build passes (vite build)
- [x] Lint passes (eslint)
- [x] All 17 tests pass (vitest)
- [ ] Manual test: create/edit/delete tasks
- [ ] Manual test: drag-drop between days
- [ ] Manual test: status changes + undo
- [ ] Manual test: dark mode toggle
- [ ] Manual test: mobile responsive layout
- [ ] Manual test: Firestore persistence after sign-in