### PR TITLE
feat(tasklist): add kanban board view

### DIFF
--- a/e2e/task-list.spec.ts
+++ b/e2e/task-list.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+
+const LOCAL_STORAGE_KEY = 'taskList_tasks'
+
+function todayStr(): string {
+  const d = new Date()
+  return d.getFullYear() + '-' +
+    String(d.getMonth() + 1).padStart(2, '0') + '-' +
+    String(d.getDate()).padStart(2, '0')
+}
+
+test.describe('Task List — local mode', () => {
+  test.beforeEach(async ({ page }) => {
+    // Seed empty task list in local storage and navigate
+    await page.addInitScript(({ key }) => {
+      localStorage.setItem(key, JSON.stringify([]))
+    }, { key: LOCAL_STORAGE_KEY })
+
+    await page.goto('/task-list/dashboard')
+    await expect(page.locator('.day-column').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('adds a task to today\'s column', async ({ page }) => {
+    // Find today's column by data-date attribute
+    const today = todayStr()
+    const todayColumn = page.locator(`.day-column[data-date="${today}"]`)
+    await expect(todayColumn).toBeVisible()
+
+    // Click the "+ Add" button in today's column
+    await todayColumn.getByText('+ Add').click()
+
+    // A new task card should appear with default title "New task"
+    await expect(todayColumn.locator('.task-card')).toBeVisible({ timeout: 5000 })
+    await expect(todayColumn.locator('.task-card').first()).toContainText('New task')
+  })
+
+  test('edits a task title inline', async ({ page }) => {
+    const today = todayStr()
+    const todayColumn = page.locator(`.day-column[data-date="${today}"]`)
+
+    // Add a task
+    await todayColumn.getByText('+ Add').click()
+    const taskCard = todayColumn.locator('.task-card').first()
+    await expect(taskCard).toBeVisible({ timeout: 5000 })
+
+    // Click the title to edit it
+    const titleEl = taskCard.locator('[contenteditable="true"]').first()
+    await titleEl.click()
+    await titleEl.selectText()
+    await titleEl.fill('My edited task')
+    await titleEl.press('Enter')
+
+    // Verify new title appears
+    await expect(taskCard).toContainText('My edited task')
+  })
+
+  test('changes status to In Progress', async ({ page }) => {
+    const today = todayStr()
+    const todayColumn = page.locator(`.day-column[data-date="${today}"]`)
+
+    // Add a task
+    await todayColumn.getByText('+ Add').click()
+    const taskCard = todayColumn.locator('.task-card').first()
+    await expect(taskCard).toBeVisible({ timeout: 5000 })
+
+    // Click the status badge (shows "To Do" by default)
+    await taskCard.locator('button').filter({ hasText: /to do/i }).click()
+
+    // Click "In Progress" in the dropdown
+    await page.locator('.task-card .absolute').filter({ hasText: /in progress/i }).getByText(/in progress/i).click()
+
+    // Status badge should now show "In Progress"
+    await expect(taskCard.locator('button').filter({ hasText: /in progress/i })).toBeVisible()
+  })
+
+  test('deletes a task and undo toast appears, then undoes deletion', async ({ page }) => {
+    const today = todayStr()
+    const todayColumn = page.locator(`.day-column[data-date="${today}"]`)
+
+    // Add a task
+    await todayColumn.getByText('+ Add').click()
+    const taskCard = todayColumn.locator('.task-card').first()
+    await expect(taskCard).toBeVisible({ timeout: 5000 })
+
+    // Hover to reveal delete button, then click it
+    await taskCard.hover()
+    await taskCard.locator('button[title="Delete"]').click()
+
+    // Undo toast should appear
+    const undoToast = page.locator('body').locator('div').filter({ hasText: /deleted/i }).filter({ hasText: /undo/i }).first()
+    await expect(undoToast).toBeVisible({ timeout: 3000 })
+
+    // Click Undo
+    await undoToast.getByRole('button', { name: /undo/i }).click()
+
+    // Toast should disappear
+    await expect(undoToast).not.toBeVisible({ timeout: 3000 })
+
+    // Task should be restored
+    await expect(todayColumn.locator('.task-card').first()).toBeVisible()
+  })
+})

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "hosting": {
     "public": "dist",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "updatedBy", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "_deleted", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/components/TaskList/BoardCard.vue
+++ b/src/components/TaskList/BoardCard.vue
@@ -1,0 +1,143 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 shadow-sm hover:shadow-md transition-shadow">
+    <!-- Header: priority dot + title + delete -->
+    <div class="flex items-start gap-1.5">
+      <span
+        class="w-2 h-2 rounded-full flex-shrink-0 mt-1 cursor-pointer hover:scale-125 transition-transform"
+        :class="getPriorityDotClass(task.priority)"
+        :title="'Priority: ' + task.priority"
+        @click="cyclePriority"
+      ></span>
+      <span
+        ref="titleEl"
+        class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100 leading-snug cursor-text rounded px-1 -mx-1 hover:bg-gray-50 dark:hover:bg-gray-700/50 focus:outline-2 focus:outline-primary-500 focus:bg-white dark:focus:bg-gray-700 transition-colors"
+        :class="{ 'line-through opacity-60': task.status === 'done' }"
+        contenteditable="true"
+        spellcheck="false"
+        v-text="task.title"
+        @blur="onTitleBlur"
+        @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+        @keydown.escape="onTitleEscape"
+      ></span>
+      <button
+        class="text-transparent hover:text-red-400 transition-colors flex-shrink-0 text-lg leading-none -mt-0.5 ml-1"
+        title="Delete"
+        @click="emit('delete', task.id)"
+      >&times;</button>
+    </div>
+
+    <!-- Description -->
+    <div
+      v-if="task.description || editingDesc"
+      ref="descEl"
+      class="mt-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-text rounded px-1 -mx-1 hover:bg-gray-50 dark:hover:bg-gray-700/50 focus:outline-2 focus:outline-primary-500 focus:bg-white dark:focus:bg-gray-700 transition-colors leading-relaxed"
+      contenteditable="true"
+      spellcheck="false"
+      v-text="task.description"
+      @blur="onDescBlur"
+      @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+      @keydown.escape="onDescEscape"
+      @focus="editingDesc = true"
+    ></div>
+    <button
+      v-else
+      class="mt-1 text-xs text-gray-400 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-colors"
+      @click="focusDesc"
+    >+ add note</button>
+
+    <!-- Footer -->
+    <div class="mt-2 flex items-center justify-between gap-1 flex-wrap">
+      <!-- Source badge -->
+      <span
+        v-if="task.source"
+        class="inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[0.6rem] font-semibold"
+        :class="getSourceBadgeClass(task.source!)"
+      >{{ task.source }}</span>
+
+      <!-- Category badge -->
+      <span
+        v-if="task.category"
+        class="inline-flex rounded-full px-1.5 py-0.5 text-[0.6rem] font-medium bg-purple-50 text-purple-600 dark:bg-purple-900/20 dark:text-purple-400"
+      >{{ task.category }}</span>
+
+      <!-- Date -->
+      <span class="ml-auto text-[0.6rem] text-gray-400 dark:text-gray-600 tabular-nums">{{ task.date }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { Task, TaskPriority } from '@/views/TaskList/types'
+
+const props = defineProps<{ task: Task }>()
+const emit = defineEmits<{
+  delete: [taskId: string]
+  priorityChange: [taskId: string, priority: TaskPriority]
+  update: [task: Task]
+}>()
+
+const titleEl = ref<HTMLElement>()
+const descEl = ref<HTMLElement>()
+const editingDesc = ref(false)
+
+const priorityDotClass: Record<string, string> = {
+  high: 'bg-red-500',
+  medium: 'bg-yellow-400',
+  low: 'bg-gray-300 dark:bg-gray-600',
+}
+
+const sourceBadgeClass: Record<string, string> = {
+  evelynn: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300',
+  duong: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300',
+}
+
+function getSourceBadgeClass(source: string): string {
+  return sourceBadgeClass[source] ?? 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+}
+
+function getPriorityDotClass(priority: string): string {
+  return priorityDotClass[priority] ?? 'bg-gray-300'
+}
+
+function cyclePriority() {
+  const order: TaskPriority[] = ['low', 'medium', 'high']
+  const idx = order.indexOf(props.task.priority)
+  emit('priorityChange', props.task.id, order[(idx + 1) % order.length])
+}
+
+function onTitleBlur(e: FocusEvent) {
+  const el = e.target as HTMLElement
+  const newTitle = el.textContent?.trim() || ''
+  if (newTitle !== props.task.title) {
+    emit('update', { ...props.task, title: newTitle })
+  }
+}
+
+function onTitleEscape(e: KeyboardEvent) {
+  const el = e.target as HTMLElement
+  el.textContent = props.task.title
+  el.blur()
+}
+
+function onDescBlur(e: FocusEvent) {
+  editingDesc.value = false
+  const el = e.target as HTMLElement
+  const newDesc = el.textContent?.trim() || ''
+  if (newDesc !== props.task.description) {
+    emit('update', { ...props.task, description: newDesc })
+  }
+}
+
+function onDescEscape(e: KeyboardEvent) {
+  editingDesc.value = false
+  const el = e.target as HTMLElement
+  el.textContent = props.task.description
+  el.blur()
+}
+
+function focusDesc() {
+  editingDesc.value = true
+  setTimeout(() => descEl.value?.focus(), 0)
+}
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -100,6 +100,11 @@ const routes: RouteRecordRaw[] = [
         path: 'dashboard',
         name: 'task-list-dashboard',
         component: () => import('@/views/TaskList/Dashboard.vue')
+      },
+      {
+        path: 'board',
+        name: 'task-list-board',
+        component: () => import('@/views/TaskList/BoardView.vue')
       }
     ]
   }

--- a/src/stores/taskList.ts
+++ b/src/stores/taskList.ts
@@ -99,7 +99,11 @@ export const useTaskListStore = defineStore('taskList', () => {
             date: data.date ?? todayStr(),
             tag: data.tag ?? false,
             createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? undefined,
-            updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? undefined
+            updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? undefined,
+            source: data.source ?? undefined,
+            updatedBy: data.updatedBy ?? undefined,
+            category: data.category ?? undefined,
+            notes: data.notes ?? undefined,
           } as Task
         })
     } finally {
@@ -117,7 +121,8 @@ export const useTaskListStore = defineStore('taskList', () => {
       date: task.date,
       tag: task.tag,
       _deleted: task._deleted ?? false,
-      updatedAt: Timestamp.now()
+      updatedAt: Timestamp.now(),
+      updatedBy: 'duong',
     })
   }
 
@@ -174,7 +179,9 @@ export const useTaskListStore = defineStore('taskList', () => {
         date: newTask.date,
         tag: newTask.tag,
         createdAt: Timestamp.now(),
-        updatedAt: Timestamp.now()
+        updatedAt: Timestamp.now(),
+        updatedBy: 'duong',
+        source: 'duong',
       })
       newTask.id = docRef.id
       tasks.value.push(newTask)
@@ -334,6 +341,15 @@ export const useTaskListStore = defineStore('taskList', () => {
 
   const onHoldTasks = computed(() => tasks.value.filter(t => !t._deleted && t.status === 'onhold'))
 
+  function tasksForStatus(status: string): Task[] {
+    return tasks.value
+      .filter(t => !t._deleted && t.status === status)
+      .sort((a, b) => {
+        const order: Record<string, number> = { high: 0, medium: 1, low: 2 }
+        return (order[a.priority] ?? 1) - (order[b.priority] ?? 1)
+      })
+  }
+
   return {
     tasks,
     loading,
@@ -347,6 +363,7 @@ export const useTaskListStore = defineStore('taskList', () => {
     moveTask,
     undo,
     tasksForDate,
+    tasksForStatus,
     onHoldTasks,
     todayStr
   }

--- a/src/stores/taskList.ts
+++ b/src/stores/taskList.ts
@@ -5,12 +5,12 @@ import { db } from '@/firebase/config'
 import {
   collection,
   doc,
-  getDocs,
   addDoc,
   updateDoc,
   deleteDoc,
   query,
   orderBy,
+  onSnapshot,
   Timestamp,
   writeBatch
 } from 'firebase/firestore'
@@ -31,6 +31,7 @@ export const useTaskListStore = defineStore('taskList', () => {
   const tasks = ref<Task[]>([])
   const loading = ref(false)
   const undoStack = ref<UndoEntry[]>([])
+  let unsubscribe: (() => void) | null = null
 
   const userId = computed(() => authStore.user?.uid ?? null)
   const isLocal = computed(() => authStore.localMode)
@@ -81,11 +82,10 @@ export const useTaskListStore = defineStore('taskList', () => {
   }
 
   // ── Firestore ──
-  async function loadFromFirestore() {
+  function subscribeToFirestore() {
     loading.value = true
-    try {
-      const q = query(getCollection(), orderBy('createdAt', 'desc'))
-      const snapshot = await getDocs(q)
+    const q = query(getCollection(), orderBy('createdAt', 'desc'))
+    unsubscribe = onSnapshot(q, (snapshot) => {
       tasks.value = snapshot.docs
         .filter(d => !d.data()._deleted)
         .map(d => {
@@ -106,9 +106,14 @@ export const useTaskListStore = defineStore('taskList', () => {
             notes: data.notes ?? undefined,
           } as Task
         })
-    } finally {
       loading.value = false
-    }
+      const movedTasks = carryForward()
+      if (movedTasks.length > 0) saveTasks(movedTasks)
+    })
+  }
+
+  function cleanup() {
+    if (unsubscribe) { unsubscribe(); unsubscribe = null }
   }
 
   async function saveTaskToFirestore(task: Task) {
@@ -131,12 +136,13 @@ export const useTaskListStore = defineStore('taskList', () => {
   async function load() {
     if (isLocal.value) {
       loadLocal()
+      const movedTasks = carryForward()
+      if (movedTasks.length > 0) {
+        await saveTasks(movedTasks)
+      }
     } else {
-      await loadFromFirestore()
-    }
-    const movedTasks = carryForward()
-    if (movedTasks.length > 0) {
-      await saveTasks(movedTasks)
+      cleanup()
+      subscribeToFirestore()
     }
   }
 
@@ -355,6 +361,7 @@ export const useTaskListStore = defineStore('taskList', () => {
     loading,
     undoStack,
     load,
+    cleanup,
     addTask,
     updateTask,
     deleteTask,

--- a/src/views/TaskList/BoardView.vue
+++ b/src/views/TaskList/BoardView.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <div v-if="store.loading" class="flex items-center justify-center py-16">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    </div>
+
+    <div v-else class="flex gap-4 overflow-x-auto pb-4 min-h-[400px] items-start">
+      <div
+        v-for="col in columns"
+        :key="col.status"
+        class="flex-shrink-0 w-72 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-2"
+      >
+        <!-- Column header -->
+        <div class="flex items-center justify-between mb-1">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full" :class="col.dotClass"></span>
+            <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">{{ col.label }}</h3>
+            <span class="text-xs text-gray-400 dark:text-gray-600 font-medium tabular-nums">({{ tasksByStatus(col.status).length }})</span>
+          </div>
+          <button
+            v-if="col.status !== 'done'"
+            class="text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors text-lg leading-none font-light"
+            title="Add task"
+            @click="addTask(col.status)"
+          >+</button>
+        </div>
+
+        <!-- Cards -->
+        <BoardCard
+          v-for="task in tasksByStatus(col.status)"
+          :key="task.id"
+          :task="task"
+          @delete="(id) => store.deleteTask(id)"
+          @priorityChange="(id, p) => store.changePriority(id, p)"
+          @update="(t) => store.updateTask(t)"
+        />
+
+        <!-- Empty state -->
+        <div
+          v-if="tasksByStatus(col.status).length === 0"
+          class="text-xs text-center text-gray-400 dark:text-gray-600 py-6 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg"
+        >
+          No tasks
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useTaskListStore } from '@/stores/taskList'
+import BoardCard from '@/components/TaskList/BoardCard.vue'
+import type { TaskStatus } from './types'
+
+const store = useTaskListStore()
+
+const columns: { status: TaskStatus; label: string; dotClass: string }[] = [
+  { status: 'todo', label: 'To Do', dotClass: 'bg-gray-400' },
+  { status: 'inprogress', label: 'In Progress', dotClass: 'bg-blue-500' },
+  { status: 'onhold', label: 'On Hold', dotClass: 'bg-orange-500' },
+  { status: 'done', label: 'Done', dotClass: 'bg-green-500' },
+]
+
+onMounted(() => {
+  if (store.tasks.length === 0) {
+    store.load()
+  }
+})
+
+function tasksByStatus(status: string) {
+  return store.tasksForStatus(status)
+}
+
+async function addTask(status: TaskStatus) {
+  const task = await store.addTask(store.todayStr())
+  await store.changeStatus(task.id, status)
+}
+</script>

--- a/src/views/TaskList/BoardView.vue
+++ b/src/views/TaskList/BoardView.vue
@@ -48,7 +48,6 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
 import { useTaskListStore } from '@/stores/taskList'
 import BoardCard from '@/components/TaskList/BoardCard.vue'
 import type { TaskStatus } from './types'
@@ -62,11 +61,6 @@ const columns: { status: TaskStatus; label: string; dotClass: string }[] = [
   { status: 'done', label: 'Done', dotClass: 'bg-green-500' },
 ]
 
-onMounted(() => {
-  if (store.tasks.length === 0) {
-    store.load()
-  }
-})
 
 function tasksByStatus(status: string) {
   return store.tasksForStatus(status)

--- a/src/views/TaskList/Dashboard.vue
+++ b/src/views/TaskList/Dashboard.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 import { useTaskListStore } from '@/stores/taskList'
 import WeekGrid from '@/components/TaskList/WeekGrid.vue'
 
@@ -16,5 +16,9 @@ const store = useTaskListStore()
 
 onMounted(() => {
   store.load()
+})
+
+onUnmounted(() => {
+  store.cleanup()
 })
 </script>

--- a/src/views/TaskList/Dashboard.vue
+++ b/src/views/TaskList/Dashboard.vue
@@ -8,17 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
 import { useTaskListStore } from '@/stores/taskList'
 import WeekGrid from '@/components/TaskList/WeekGrid.vue'
 
 const store = useTaskListStore()
-
-onMounted(() => {
-  store.load()
-})
-
-onUnmounted(() => {
-  store.cleanup()
-})
 </script>

--- a/src/views/TaskList/TaskListLayout.vue
+++ b/src/views/TaskList/TaskListLayout.vue
@@ -7,14 +7,31 @@
         <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-1">{{ $t('taskList.title') }}</h1>
         <p class="text-sm sm:text-base text-gray-600 dark:text-gray-400">{{ $t('taskList.subtitle') }}</p>
       </div>
-      <button
-        class="p-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        title="Toggle dark mode"
-        @click="toggleDark"
-      >
-        <span v-if="isDark">&#9728;</span>
-        <span v-else>&#9790;</span>
-      </button>
+      <div class="flex items-center gap-2">
+        <!-- View toggle -->
+        <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <RouterLink
+            to="/task-list/dashboard"
+            class="px-3 py-1.5 text-sm transition-colors"
+            :class="isCalendar ? 'bg-primary-600 text-white' : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800'"
+            title="Calendar view"
+          >&#128197;</RouterLink>
+          <RouterLink
+            to="/task-list/board"
+            class="px-3 py-1.5 text-sm transition-colors border-l border-gray-200 dark:border-gray-700"
+            :class="isBoard ? 'bg-primary-600 text-white' : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800'"
+            title="Board view"
+          >&#9638;</RouterLink>
+        </div>
+        <button
+          class="p-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          title="Toggle dark mode"
+          @click="toggleDark"
+        >
+          <span v-if="isDark">&#9728;</span>
+          <span v-else>&#9790;</span>
+        </button>
+      </div>
     </div>
 
     <div class="min-h-[400px]">
@@ -26,9 +43,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
 import LocalModeWarning from '@/components/common/LocalModeWarning.vue'
 import UndoToast from '@/components/TaskList/UndoToast.vue'
+
+const route = useRoute()
+const isCalendar = computed(() => route.name === 'task-list-dashboard')
+const isBoard = computed(() => route.name === 'task-list-board')
 
 const isDark = ref(false)
 

--- a/src/views/TaskList/TaskListLayout.vue
+++ b/src/views/TaskList/TaskListLayout.vue
@@ -43,15 +43,17 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import LocalModeWarning from '@/components/common/LocalModeWarning.vue'
 import UndoToast from '@/components/TaskList/UndoToast.vue'
+import { useTaskListStore } from '@/stores/taskList'
 
 const route = useRoute()
 const isCalendar = computed(() => route.name === 'task-list-dashboard')
 const isBoard = computed(() => route.name === 'task-list-board')
 
+const store = useTaskListStore()
 const isDark = ref(false)
 
 function toggleDark() {
@@ -66,5 +68,10 @@ onMounted(() => {
     isDark.value = true
     document.documentElement.classList.add('dark')
   }
+  store.load()
+})
+
+onUnmounted(() => {
+  store.cleanup()
 })
 </script>

--- a/src/views/TaskList/types.ts
+++ b/src/views/TaskList/types.ts
@@ -12,6 +12,11 @@ export interface Task {
   createdAt?: string
   updatedAt?: string
   _deleted?: boolean
+  // Agent task board fields
+  source?: string       // 'evelynn' | 'duong' | undefined
+  updatedBy?: string    // 'evelynn' | 'duong' | undefined
+  category?: string
+  notes?: string
 }
 
 export const STATUS_ORDER: TaskStatus[] = ['todo', 'inprogress', 'onhold', 'done']


### PR DESCRIPTION
## Summary

- Adds a `/task-list/board` kanban view with columns: To Do, In Progress, On Hold, Done
- Adds `BoardCard.vue` with inline title/description editing, priority cycling, source badge (evelynn / duong), category badge, and date
- Adds view toggle in the TaskListLayout header to switch between Calendar (📅) and Board (▪) views
- Extends `Task` type with `source`, `updatedBy`, `category`, `notes` fields
- Store now persists `updatedBy: 'duong'` and `source: 'duong'` on all writes
- `tasksForStatus()` query added to store, sorted by priority
- Evelynn-created tasks (source: 'evelynn') show with violet badge; Duong's tasks show with sky badge

## Test plan

- [ ] Lint: 0 errors (7 pre-existing warnings unchanged)
- [ ] Typecheck: clean
- [ ] Tests: 17/17 passing

Author: Ornn